### PR TITLE
fix: mobile layout fixes, adjust flex behavior, hide extra pagination options, adjust fixed columns

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -27,57 +27,74 @@
                             <div id="inputs">
                                 <el-form :model="addCubeForm" :inline="true" @submit.prevent="submitAddCubeForm" v-loading="addCubeForm.loading">
                                     <el-form-item>
-                                        <el-select label="Collections" v-model="addCubeForm.presetComparisonsSelection" @change="loadPresetCollection" placeholder="Load Collection..." style="width: 200px;">
-                                            <el-option
-                                                v-for="option in presetComparisonsSelect"
-                                                :key="option.value"
-                                                :label="option.label"
-                                                :value="option.value"
-                                            />
-                                        </el-select>
-                                    </el-form-item>
-                                    <el-form-item>OR</el-form-item>
-                                    <el-form-item style="margin-right: 6px;">
-                                        <el-input v-model="addCubeForm.cubeId" placeholder="Enter Cube ID" autofocus />
-                                    </el-form-item>
-                                    <el-form-item>
-                                        <el-button type="primary" @click="submitAddCubeForm" :disabled="addCubeForm.loading">Add</el-button>
-                                        <input type="submit" style="display: none;" />
+                                        <el-col :span="11" :xs="24" :sm="24" :md="11" :lg="11">
+                                            <el-form-item style="min-width: 200px; width: 100%;">
+                                                <el-select label="Collections" v-model="addCubeForm.presetComparisonsSelection" @change="loadPresetCollection" placeholder="Load Collection..." >
+                                                    <el-option
+                                                        v-for="option in presetComparisonsSelect"
+                                                        :key="option.value"
+                                                        :label="option.label"
+                                                        :value="option.value"
+                                                    />
+                                                </el-select>
+                                            </el-form-item>
+                                        </el-col>
+                                        <el-col :span="2" :xs="0" :sm="0" :md="2" :lg="2" style="text-align: center;">
+                                            <span class="text-gray-500">OR</span>
+                                        </el-col>
+                                        <el-col :span="11" :xs="24" :sm="24" :md="11" :lg="11" style="display: flex; align-items: center;">
+                                            <el-row :gutter="10">
+                                                <el-col :span="20">
+                                                    <el-form-item style="min-width: 200px; width: 100%;">
+                                                        <el-input v-model="addCubeForm.cubeId" placeholder="Enter Cube ID" autofocus />
+                                                    </el-form-item>
+                                                </el-col>
+                                                <el-col :span="4">
+                                                    <el-form-item>
+                                                        <el-button type="primary" @click="submitAddCubeForm" :disabled="addCubeForm.loading">Add</el-button>
+                                                        <input type="submit" style="display: none;" />
+                                                    </el-form-item>
+                                                </el-col>
+                                            </el-row>
+                                        </el-col>
                                     </el-form-item>
                                 </el-form>
                             </div>
-
-                            <el-space direction="horizontal" style="width: 100%; justify-content: space-between; align-items: center; margin-bottom: 1em;">
-                                <!-- <el-text tag="i">Loaded Cubes: {{ Object.keys(loadedCubes).length }}</el-text> -->
-                                <el-form :inline="true" style="justify-content: flex-end; display: flex;">
-                                    <el-form-item label="Exclude Lands:">
-                                        <el-switch v-model="config.excludeLands" active-color="#13ce66" inactive-color="#ff4949" />
-                                    </el-form-item>
-                                    <el-form-item label="Columns:">
-                                        <el-select
-                                            v-model="config.visibleColumns"
-                                            multiple
-                                            collapse-tags
-                                            label="Visible Columns"
-                                            placeholder="Select columns"
-                                            style="width:250px;"
-                                        >
-                                            <el-option-group
-                                                v-for="group in columnOptions"
-                                                :key="group.label"
-                                                :label="group.label"
-                                            >
-                                                <el-option
-                                                    v-for="item in group.options"
-                                                    :key="item.value"
-                                                    :label="item.label"
-                                                    :value="item.value"
-                                                />
-                                            </el-option-group>
-                                        </el-select>
+                            <div id="config">
+                                <el-form :inline="true">
+                                    <el-form-item>
+                                        <el-col :span="10" :xs="24" :sm="24" :md="10" :lg="10">
+                                            <el-form-item label="Exclude Lands:">
+                                                <el-switch v-model="config.excludeLands" active-color="#13ce66" inactive-color="#ff4949" />
+                                            </el-form-item>
+                                        </el-col>
+                                        <el-col :span="14" :xs="24" :sm="24" :md="14" :lg="14">
+                                            <el-form-item label="Columns:" style="width: 100%;">
+                                                <el-select
+                                                    v-model="config.visibleColumns"
+                                                    multiple
+                                                    collapse-tags
+                                                    label="Visible Columns"
+                                                    placeholder="Select columns"
+                                                >
+                                                    <el-option-group
+                                                        v-for="group in columnOptions"
+                                                        :key="group.label"
+                                                        :label="group.label"
+                                                    >
+                                                        <el-option
+                                                            v-for="item in group.options"
+                                                            :key="item.value"
+                                                            :label="item.label"
+                                                            :value="item.value"
+                                                        />
+                                                    </el-option-group>
+                                                </el-select>
+                                            </el-form-item>
+                                        </el-col>
                                     </el-form-item>
                                 </el-form>
-                            </el-space>
+                            </div>
 
                             <el-table
                                 :data="overviewTableData"
@@ -87,7 +104,7 @@
                                 table-layout="auto"
                                 stripe
                             >
-                                <el-table-column fixed width="25" type="expand">
+                                <el-table-column :fixed="!isMobile" width="25" type="expand">
                                     <template #default="props">
                                         <el-row>
                                             <el-col :span="14" :xs="24" :sm="24" :md="24" :xl="16">
@@ -138,7 +155,7 @@
                                         </el-button>
                                     </template>
                                 </el-table-column>
-                                <el-table-column fixed type="index" label="#" width="50" v-if="config.visibleColumns.includes('rowNumber')" />
+                                <el-table-column type="index" label="#" width="50" v-if="config.visibleColumns.includes('rowNumber')" />
                                 <el-table-column prop="name" label="Name" min-width="150" max-width="300" show-overflow-tooltip sortable v-if="config.visibleColumns.includes('name')" >
                                     <template #default="{ row }">
                                         <el-link :href="`https://cubecobra.com/cube/overview/${row.id}`" target="_blank">{{ row.name }}</el-link>
@@ -298,6 +315,10 @@ const defaultConfig = {
         'stats.percentages.makesTokens',
     ],
 };
+
+const isMobile = computed(() => {
+  return screen.width <= 760;
+});
 
 const config = bindStorage('appConfig', (v) => {
     if (v == undefined || v === null) {

--- a/src/components/CardSummaryTable.vue
+++ b/src/components/CardSummaryTable.vue
@@ -1,6 +1,7 @@
 <template>
     <el-row
         direction="horizontal"
+        :gutter="20"
     >
         <el-col :span="12" :xs="24">
             <el-space>
@@ -18,7 +19,7 @@
                 <el-button @click="resetFilters">Reset Filters</el-button>
             </el-space>
         </el-col>
-        <el-col :span="12" :xs="24" style="text-align: right;">
+        <el-col :span="12" :xs="24" class="filtered-count">
             <el-text tag="i">Filtered to {{ searchedRows.length }} / {{ sortedRows.length }} Cards</el-text>
         </el-col>
     </el-row>
@@ -27,7 +28,8 @@
         v-model:current-page="currentPage"
         v-model:page-size="pageSize"
         :page-sizes="[25, 50, 100, 250]"
-        layout="->, prev, pager, next, sizes"
+        :pager-count="5"
+        :layout="paginationLayout"
         :total="searchedRows.length"
     />
 
@@ -42,7 +44,7 @@
         table-layout="auto"
         stripe
     >
-        <el-table-column fixed width="25" type="expand">
+        <el-table-column :fixed="!isMobile" width="25" type="expand">
             <template #default="props">
                 <el-row class="expanded-content" :gutter="20" justify="space-around">
                     <el-col :span="8" :xs="24" :sm="24" :md="8" :xl="8">
@@ -93,7 +95,7 @@
             </template>
         </el-table-column>
 
-        <el-table-column fixed prop="index" label="#" width="50" />
+        <el-table-column :fixed="!isMobile" prop="index" label="#" width="50" />
         <el-table-column prop="name" label="Name" min-width="150" max-width="300" sortable="custom">
             <template #default="{ row }">
                 <el-link :href="`https://scryfall.com/card/${row.setCode?.toLowerCase()}/${row.collectorNumber}`" target="_blank">{{ row.name }}</el-link>
@@ -211,7 +213,8 @@
         v-model:current-page="currentPage"
         v-model:page-size="pageSize"
         :page-sizes="[25, 50, 100, 250]"
-        layout="->, prev, pager, next, sizes"
+        :pager-count="5"
+        :layout="paginationLayout"
         :total="searchedRows.length"
     />
 </template>
@@ -239,6 +242,14 @@ const pageSize = ref(50);
 const searchInput = ref('');
 const activeFilters = ref({});
 const activeSort = ref<SortBy | null>({ prop: 'cubeCount', order: 'descending' });
+
+const isMobile = computed(() => {
+  return screen.width <= 760;
+});
+
+const paginationLayout = computed(() => {
+    return isMobile.value ? 'prev, pager, next' : '->, prev, pager, next, sizes';
+});
 
 const expandedCubeList = (cubeKeys: string[]) => {
     const resp = Object.entries(props.loadedCubes).map(([key, cube]) => {
@@ -467,9 +478,18 @@ const visibleRows = computed(() => {
 </script>
 
 <style lang="scss">
+.filtered-count {
+    text-align: right;
+    line-height: 2em;
+
+    @media (max-width: 760px) {
+        text-align: left;
+        margin-top: 8px;
+    }
+}
+
 .el-pagination {
-    margin-top: 16px;
-    margin-bottom: 16px;
+    margin: 16px auto;
     text-align: right;
 }
 


### PR DESCRIPTION
The vue mobile detection function is bad and I should look at ways to make that reactive to window size changes + move it to some global instead of being scoped to the component.