### PR TITLE
feat: add checks implementation

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -115,6 +115,9 @@ import presetsJson from '../preloads/generated/presets.json';
 const presetCollections: PresetCollection[] = presetsJson as PresetCollection[];
 import { bindStorage } from './util/VueLocalStorage';
 import type { UserCollection, Cube } from './types';
+import type { ChecksState, CheckResult } from './types';
+import { parseCheckExpression } from './util/CheckExpressionParser';
+import { evaluateCheck } from './util/CheckEvaluator';
 import { THEME_KEY } from 'vue-echarts';
 import { getRandomFooter } from './util/RandomFooter';
 import { initScryfall, remapCube, enrichCube, preloadSimiliarityMatrix, computeSimilarityMatrix, updateSimilarityForCube, removeSimilarityForCube } from './util/CubeFunctions';
@@ -376,6 +379,11 @@ const presetComparisonsSelect = ref([...availablePresets].map(label => ({ label,
 
 const userCollections = bindStorage<UserCollection[]>('user-collections', v => Array.isArray(v) ? v : []);
 
+const checksState = bindStorage<ChecksState>('cube-checks', v => {
+    if (v && typeof v === 'object' && Array.isArray((v as any).collections)) return v as ChecksState;
+    return { collections: [], activeCollectionId: null };
+});
+
 const similarityMatrix = ref<Record<string, Record<string, import('./types').SimilarityScore>>>({});
 
 const getAverageSimilarityScore = (cubeId: string) => {
@@ -403,6 +411,30 @@ const overviewTableData = computed(() => {
             avgSimilarityScore: getAverageSimilarityScore(id),
         }
     });
+});
+
+const checkResults = computed<Map<string, Map<string, CheckResult>>>(() => {
+    const results = new Map<string, Map<string, CheckResult>>();
+    const activeId = checksState.value.activeCollectionId;
+    if (!activeId) return results;
+    const collection = checksState.value.collections.find(c => c.id === activeId);
+    if (!collection) return results;
+
+    const parsedConditions = collection.conditions
+        .map(cond => ({ id: cond.id, parsed: parseCheckExpression(cond.expression) }))
+        .filter(c => c.parsed.expression !== null);
+
+    for (const [cubeId, cube] of Object.entries(visibleLoadedCubes.value)) {
+        const cubeResults = new Map<string, CheckResult>();
+        const ctx = { loadedCubes: loadedCubes.value };
+        for (const { id, parsed } of parsedConditions) {
+            if (parsed.expression) {
+                cubeResults.set(id, evaluateCheck(parsed.expression, cube.cards, ctx));
+            }
+        }
+        results.set(cubeId, cubeResults);
+    }
+    return results;
 });
 
 const peerStats = computed(() => {
@@ -778,6 +810,8 @@ provide('refreshCube', refreshCube);
 provide('addCube', addCube);
 provide('addSnapshot', addSnapshot);
 provide('removeCube', removeCube);
+provide('checksState', checksState);
+provide('checkResults', checkResults);
 
 onMounted(async () => {
     // Start data initialization in the background without blocking the UI

--- a/src/App.vue
+++ b/src/App.vue
@@ -63,6 +63,10 @@
                             <CardsTab :loadedCubes="visibleLoadedCubes" :similarityMatrix="similarityMatrix" :overviewTableData="overviewTableData" :loadingProgress="loadingProgress" />
                         </el-tab-pane>
 
+                        <el-tab-pane label="Checks" name="checks" :lazy="true">
+                            <ChecksTab :loaded-cubes="visibleLoadedCubes" />
+                        </el-tab-pane>
+
                         <el-tab-pane label="About" name="about" :lazy="true">
                             <About />
                         </el-tab-pane>
@@ -137,6 +141,7 @@ import StatisticsTab from './tabs/StatisticsTab.vue';
 import InfographicTab from './tabs/InfographicTab.vue';
 import CardsTab from './tabs/CardsTab.vue';
 import ComparisonTab from './tabs/ComparisonTab.vue';
+import ChecksTab from './tabs/ChecksTab.vue';
 
 registerTheme('darkbmj', darkbmjTheme);
 provide(THEME_KEY, 'darkbmj');

--- a/src/App.vue
+++ b/src/App.vue
@@ -107,7 +107,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, reactive, watch, provide, onMounted, nextTick } from 'vue';
+import { ref, shallowRef, computed, reactive, watch, watchEffect, provide, onMounted, nextTick } from 'vue';
 import type { SortDirection } from './util/SortConfig';
 import { stripSortTokens } from './util/SortConfig';
 import { useHashRouter } from './util/useHashRouter';
@@ -418,28 +418,54 @@ const overviewTableData = computed(() => {
     });
 });
 
-const checkResults = computed<Map<string, Map<string, CheckResult>>>(() => {
+const checkResults = shallowRef<Map<string, Map<string, CheckResult>>>(new Map());
+
+// Cache keyed by `cubeId::conditionId::expression` to avoid redundant evaluation.
+const _checkResultsCache = new Map<string, CheckResult>();
+
+watchEffect(() => {
     const results = new Map<string, Map<string, CheckResult>>();
     const activeId = checksState.value.activeCollectionId;
-    if (!activeId) return results;
+    if (!activeId) {
+        checkResults.value = results;
+        return;
+    }
     const collection = checksState.value.collections.find(c => c.id === activeId);
-    if (!collection) return results;
+    if (!collection) {
+        checkResults.value = results;
+        return;
+    }
 
     const parsedConditions = collection.conditions
-        .map(cond => ({ id: cond.id, parsed: parseCheckExpression(cond.expression) }))
+        .map(cond => ({ id: cond.id, expression: cond.expression, parsed: parseCheckExpression(cond.expression) }))
         .filter(c => c.parsed.expression !== null);
+
+    const usedKeys = new Set<string>();
 
     for (const [cubeId, cube] of Object.entries(visibleLoadedCubes.value)) {
         const cubeResults = new Map<string, CheckResult>();
         const ctx = { loadedCubes: loadedCubes.value };
-        for (const { id, parsed } of parsedConditions) {
+        for (const { id, expression, parsed } of parsedConditions) {
             if (parsed.expression) {
-                cubeResults.set(id, evaluateCheck(parsed.expression, cube.cards, ctx));
+                const cacheKey = `${cubeId}::${id}::${expression}`;
+                usedKeys.add(cacheKey);
+                let result = _checkResultsCache.get(cacheKey);
+                if (!result) {
+                    result = evaluateCheck(parsed.expression, cube.cards, ctx);
+                    _checkResultsCache.set(cacheKey, result);
+                }
+                cubeResults.set(id, result);
             }
         }
         results.set(cubeId, cubeResults);
     }
-    return results;
+
+    // Prune stale cache entries
+    for (const key of _checkResultsCache.keys()) {
+        if (!usedKeys.has(key)) _checkResultsCache.delete(key);
+    }
+
+    checkResults.value = results;
 });
 
 const peerStats = computed(() => {

--- a/src/components/CheckConditionRow.vue
+++ b/src/components/CheckConditionRow.vue
@@ -59,17 +59,19 @@ const sortedCubeResults = computed(() => {
                 placeholder="Enter check expression..."
                 :class="{ 'is-error': parseError }"
                 @input="onInput"
-            />
-            <el-tooltip v-if="parseError" :content="parseError" placement="top">
-                <el-icon class="error-icon"><Warning /></el-icon>
-            </el-tooltip>
-            <span class="pass-badge" @click="expanded = !expanded">
-                {{ passCount }}/{{ totalCount }}
-                <el-icon :class="{ expanded }"><ArrowRight /></el-icon>
-            </span>
-            <el-button text type="danger" @click="$emit('delete')">
+            >
+                <template #append>
+                    <span class="pass-count" @click="expanded = !expanded">
+                        {{ passCount }}/{{ totalCount }}
+                    </span>
+                </template>
+            </el-input>
+            <el-button type="danger" text @click="$emit('delete')">
                 <el-icon><Delete /></el-icon>
             </el-button>
+        </div>
+        <div v-if="parseError" class="parse-error">
+            {{ parseError }}
         </div>
         <div v-if="expanded" class="cube-results-list">
             <div
@@ -77,8 +79,9 @@ const sortedCubeResults = computed(() => {
                 :key="item.cubeId"
                 class="cube-result-item"
             >
-                <el-icon :class="item.result?.passed ? 'pass' : 'fail'">
-                    <component :is="item.result?.passed ? 'CircleCheck' : 'CircleClose'" />
+                <el-icon :size="16" :class="item.result?.passed ? 'pass' : 'fail'">
+                    <CircleCheck v-if="item.result?.passed" />
+                    <CircleClose v-else-if="item.result" />
                 </el-icon>
                 <span class="cube-name">{{ item.cubeName }}</span>
                 <span v-if="item.result" class="result-value">
@@ -91,51 +94,50 @@ const sortedCubeResults = computed(() => {
 
 <style scoped>
 .check-condition-row {
-  margin-bottom: 8px;
+    margin-bottom: 12px;
 }
 .condition-header {
-  display: flex;
-  align-items: center;
-  gap: 8px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
 }
 .condition-header .el-input {
-  flex: 1;
+    flex: 1;
+}
+.condition-header :deep(.el-input-group__append) {
+    cursor: pointer;
+    user-select: none;
+    min-width: 56px;
+    text-align: center;
+    font-weight: 600;
 }
 .condition-header .el-input.is-error :deep(.el-input__wrapper) {
-  box-shadow: 0 0 0 1px var(--el-color-danger) inset;
+    box-shadow: 0 0 0 1px var(--el-color-danger) inset;
 }
-.error-icon {
-  color: var(--el-color-danger);
+.pass-count {
+    font-variant-numeric: tabular-nums;
 }
-.pass-badge {
-  cursor: pointer;
-  white-space: nowrap;
-  font-size: 12px;
-  display: flex;
-  align-items: center;
-  gap: 2px;
-}
-.pass-badge .el-icon {
-  transition: transform 0.2s;
-}
-.pass-badge .el-icon.expanded {
-  transform: rotate(90deg);
+.parse-error {
+    margin-top: 4px;
+    font-size: 12px;
+    color: var(--el-color-danger);
+    padding-left: 12px;
 }
 .cube-results-list {
-  margin-top: 4px;
-  margin-left: 12px;
-  max-height: 200px;
-  overflow-y: auto;
+    margin-top: 8px;
+    margin-left: 12px;
+    max-height: 240px;
+    overflow-y: auto;
 }
 .cube-result-item {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 2px 0;
-  font-size: 12px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 0;
+    font-size: 14px;
 }
 .cube-result-item .pass { color: var(--el-color-success); }
 .cube-result-item .fail { color: var(--el-color-danger); }
 .cube-name { flex: 1; }
-.result-value { color: var(--el-text-color-secondary); }
+.result-value { color: var(--el-text-color-secondary); font-variant-numeric: tabular-nums; }
 </style>

--- a/src/components/CheckConditionRow.vue
+++ b/src/components/CheckConditionRow.vue
@@ -120,7 +120,7 @@ const sortedCubeResults = computed(() => {
 .condition-header :deep(.el-input-group__append) {
     cursor: pointer;
     user-select: none;
-    width: 70px;
+    width: 90px;
     flex-shrink: 0;
     padding: 0;
 }

--- a/src/components/CheckConditionRow.vue
+++ b/src/components/CheckConditionRow.vue
@@ -143,7 +143,7 @@ const sortedCubeResults = computed(() => {
     background: var(--el-fill-color-lighter);
     border-radius: 4px;
     display: grid;
-    grid-template-columns: 16px 1fr auto;
+    grid-template-columns: 16px auto auto 1fr;
     column-gap: 8px;
     row-gap: 4px;
     align-items: center;
@@ -158,5 +158,5 @@ const sortedCubeResults = computed(() => {
 .cube-result-item .pass { color: var(--el-color-success); }
 .cube-result-item .fail { color: var(--el-color-danger); }
 .cube-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.result-value { color: var(--el-text-color-secondary); font-variant-numeric: tabular-nums; text-align: right; }
+.result-value { color: var(--el-text-color-secondary); font-variant-numeric: tabular-nums; }
 </style>

--- a/src/components/CheckConditionRow.vue
+++ b/src/components/CheckConditionRow.vue
@@ -47,7 +47,8 @@ const sortedCubeResults = computed(() => {
   return [...props.cubeResults].sort((a, b) => {
     const aPassed = a.result?.passed ? 0 : 1;
     const bPassed = b.result?.passed ? 0 : 1;
-    return aPassed - bPassed;
+    if (aPassed !== bPassed) return aPassed - bPassed;
+    return a.cubeName.localeCompare(b.cubeName);
   });
 });
 </script>

--- a/src/components/CheckConditionRow.vue
+++ b/src/components/CheckConditionRow.vue
@@ -91,7 +91,7 @@ const sortedCubeResults = computed(() => {
                         {{ item.result.lhsValue }} vs {{ item.result.rhsValue }}
                     </template>
                     <template v-else>
-                        {{ item.result.lhsValue.toFixed(item.result.isPercentage ? 1 : 0) }}{{ item.result.isPercentage ? '%' : '' }}
+                        {{ item.result.lhsValue.toFixed(item.result.expressionType === 'aggregate' ? 2 : item.result.isPercentage ? 1 : 0) }}{{ item.result.isPercentage ? '%' : '' }}
                     </template>
                 </span>
             </div>

--- a/src/components/CheckConditionRow.vue
+++ b/src/components/CheckConditionRow.vue
@@ -60,17 +60,18 @@ const sortedCubeResults = computed(() => {
                 placeholder="Enter check expression..."
                 :class="{ 'is-error': parseError }"
                 @input="onInput"
-            />
-            <div class="condition-actions">
-                <span class="pass-count">{{ passCount }}/{{ totalCount }}</span>
-                <el-button
-                    class="expand-btn"
-                    text
-                    :icon="expanded ? ArrowDown : ArrowRight"
-                    @click="expanded = !expanded"
-                />
-                <el-button type="danger" text :icon="Delete" @click="$emit('delete')" />
-            </div>
+            >
+                <template #append>
+                    <span class="pass-count" @click="expanded = !expanded">
+                        <el-icon :size="14">
+                            <ArrowDown v-if="expanded" />
+                            <ArrowRight v-else />
+                        </el-icon>
+                        {{ passCount }}/{{ totalCount }}
+                    </span>
+                </template>
+            </el-input>
+            <el-button type="danger" text :icon="Delete" @click="$emit('delete')" />
         </div>
         <div v-if="parseError" class="parse-error">
             {{ parseError }}
@@ -114,20 +115,16 @@ const sortedCubeResults = computed(() => {
 .condition-header .el-input.is-error :deep(.el-input__wrapper) {
     box-shadow: 0 0 0 1px var(--el-color-danger) inset;
 }
-.condition-actions {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    flex-shrink: 0;
+.condition-header :deep(.el-input-group__append) {
+    cursor: pointer;
+    user-select: none;
 }
 .pass-count {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
     font-variant-numeric: tabular-nums;
-    font-size: 14px;
-    min-width: 40px;
-    text-align: right;
-}
-.expand-btn {
-    padding: 4px;
+    font-weight: 600;
 }
 .parse-error {
     margin-top: 4px;

--- a/src/components/CheckConditionRow.vue
+++ b/src/components/CheckConditionRow.vue
@@ -4,6 +4,7 @@ import { useDebounceFn } from '@vueuse/core';
 import { ArrowDown, ArrowRight, Delete, CircleCheck, CircleClose } from '@element-plus/icons-vue';
 import type { CheckCondition, CheckResult } from '../types/checks';
 import { parseCheckExpression } from '../util/CheckExpressionParser';
+import { normalizeSortName, castInensitiveSort } from '../util/HelperFunctions';
 
 const props = defineProps<{
   condition: CheckCondition;
@@ -48,7 +49,7 @@ const sortedCubeResults = computed(() => {
     const aPassed = a.result?.passed ? 0 : 1;
     const bPassed = b.result?.passed ? 0 : 1;
     if (aPassed !== bPassed) return aPassed - bPassed;
-    return a.cubeName.localeCompare(b.cubeName);
+    return castInensitiveSort(normalizeSortName(a.cubeName), normalizeSortName(b.cubeName));
   });
 });
 </script>

--- a/src/components/CheckConditionRow.vue
+++ b/src/components/CheckConditionRow.vue
@@ -1,0 +1,142 @@
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue';
+import { useDebounceFn } from '@vueuse/core';
+import type { CheckCondition, CheckResult } from '../types/checks';
+import { parseCheckExpression } from '../util/CheckExpressionParser';
+
+const props = defineProps<{
+  condition: CheckCondition;
+  cubeResults: Array<{ cubeId: string; cubeName: string; result: CheckResult | undefined }>;
+}>();
+
+const emit = defineEmits<{
+  (e: 'update:expression', value: string): void;
+  (e: 'update:label', value: string): void;
+  (e: 'delete'): void;
+}>();
+
+const localExpression = ref(props.condition.expression);
+const parseError = ref<string | null>(null);
+const expanded = ref(false);
+
+watch(() => props.condition.expression, (val) => {
+  localExpression.value = val;
+});
+
+const debouncedUpdate = useDebounceFn((val: string) => {
+  const result = parseCheckExpression(val);
+  parseError.value = result.error;
+  emit('update:expression', val);
+}, 250);
+
+function onInput(val: string) {
+  localExpression.value = val;
+  debouncedUpdate(val);
+}
+
+const passCount = computed(() => {
+  return props.cubeResults.filter(r => r.result?.passed).length;
+});
+
+const totalCount = computed(() => {
+  return props.cubeResults.length;
+});
+
+const sortedCubeResults = computed(() => {
+  return [...props.cubeResults].sort((a, b) => {
+    const aPassed = a.result?.passed ? 0 : 1;
+    const bPassed = b.result?.passed ? 0 : 1;
+    return aPassed - bPassed;
+  });
+});
+</script>
+
+<template>
+    <div class="check-condition-row">
+        <div class="condition-header">
+            <el-input
+                :model-value="localExpression"
+                placeholder="Enter check expression..."
+                :class="{ 'is-error': parseError }"
+                size="small"
+                @input="onInput"
+            />
+            <el-tooltip v-if="parseError" :content="parseError" placement="top">
+                <el-icon class="error-icon"><Warning /></el-icon>
+            </el-tooltip>
+            <span class="pass-badge" @click="expanded = !expanded">
+                {{ passCount }}/{{ totalCount }}
+                <el-icon :class="{ expanded }"><ArrowRight /></el-icon>
+            </span>
+            <el-button size="small" text type="danger" @click="$emit('delete')">
+                <el-icon><Delete /></el-icon>
+            </el-button>
+        </div>
+        <div v-if="expanded" class="cube-results-list">
+            <div
+                v-for="item in sortedCubeResults"
+                :key="item.cubeId"
+                class="cube-result-item"
+            >
+                <el-icon :class="item.result?.passed ? 'pass' : 'fail'">
+                    <component :is="item.result?.passed ? 'CircleCheck' : 'CircleClose'" />
+                </el-icon>
+                <span class="cube-name">{{ item.cubeName }}</span>
+                <span v-if="item.result" class="result-value">
+                    {{ item.result.lhsValue.toFixed(item.result.isPercentage ? 1 : 0) }}{{ item.result.isPercentage ? '%' : '' }}
+                </span>
+            </div>
+        </div>
+    </div>
+</template>
+
+<style scoped>
+.check-condition-row {
+  margin-bottom: 8px;
+}
+.condition-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.condition-header .el-input {
+  flex: 1;
+}
+.condition-header .el-input.is-error :deep(.el-input__wrapper) {
+  box-shadow: 0 0 0 1px var(--el-color-danger) inset;
+}
+.error-icon {
+  color: var(--el-color-danger);
+}
+.pass-badge {
+  cursor: pointer;
+  white-space: nowrap;
+  font-size: 12px;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+.pass-badge .el-icon {
+  transition: transform 0.2s;
+}
+.pass-badge .el-icon.expanded {
+  transform: rotate(90deg);
+}
+.cube-results-list {
+  margin-top: 4px;
+  margin-left: 12px;
+  max-height: 200px;
+  overflow-y: auto;
+}
+.cube-result-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 0;
+  font-size: 12px;
+}
+.cube-result-item .pass { color: var(--el-color-success); }
+.cube-result-item .fail { color: var(--el-color-danger); }
+.cube-name { flex: 1; }
+.result-value { color: var(--el-text-color-secondary); }
+</style>

--- a/src/components/CheckConditionRow.vue
+++ b/src/components/CheckConditionRow.vue
@@ -87,7 +87,12 @@ const sortedCubeResults = computed(() => {
                 </el-icon>
                 <span class="cube-name">{{ item.cubeName }}</span>
                 <span v-if="item.result" class="result-value">
-                    {{ item.result.lhsValue.toFixed(item.result.isPercentage ? 1 : 0) }}{{ item.result.isPercentage ? '%' : '' }}
+                    <template v-if="item.result.expressionType === 'relative'">
+                        {{ item.result.lhsValue }} vs {{ item.result.rhsValue }}
+                    </template>
+                    <template v-else>
+                        {{ item.result.lhsValue.toFixed(item.result.isPercentage ? 1 : 0) }}{{ item.result.isPercentage ? '%' : '' }}
+                    </template>
                 </span>
             </div>
         </div>

--- a/src/components/CheckConditionRow.vue
+++ b/src/components/CheckConditionRow.vue
@@ -127,7 +127,7 @@ const sortedCubeResults = computed(() => {
 .pass-count {
     display: flex;
     align-items: center;
-    justify-content: center;
+    justify-content: flex-start;
     gap: 6px;
     font-variant-numeric: tabular-nums;
     font-weight: 600;

--- a/src/components/CheckConditionRow.vue
+++ b/src/components/CheckConditionRow.vue
@@ -152,6 +152,6 @@ const sortedCubeResults = computed(() => {
 }
 .cube-result-item .pass { color: var(--el-color-success); }
 .cube-result-item .fail { color: var(--el-color-danger); }
-.cube-name { flex: 1; }
-.result-value { color: var(--el-text-color-secondary); font-variant-numeric: tabular-nums; }
+.cube-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.result-value { color: var(--el-text-color-secondary); font-variant-numeric: tabular-nums; margin-left: auto; }
 </style>

--- a/src/components/CheckConditionRow.vue
+++ b/src/components/CheckConditionRow.vue
@@ -158,5 +158,5 @@ const sortedCubeResults = computed(() => {
 .cube-result-item .pass { color: var(--el-color-success); }
 .cube-result-item .fail { color: var(--el-color-danger); }
 .cube-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.result-value { color: var(--el-text-color-secondary); font-variant-numeric: tabular-nums; }
+.result-value { color: var(--el-text-color-secondary); font-variant-numeric: tabular-nums; text-align: center; padding-left: 8px; }
 </style>

--- a/src/components/CheckConditionRow.vue
+++ b/src/components/CheckConditionRow.vue
@@ -120,7 +120,8 @@ const sortedCubeResults = computed(() => {
 .condition-header :deep(.el-input-group__append) {
     cursor: pointer;
     user-select: none;
-    min-width: 70px;
+    width: 70px;
+    flex-shrink: 0;
     padding: 0;
 }
 .pass-count {

--- a/src/components/CheckConditionRow.vue
+++ b/src/components/CheckConditionRow.vue
@@ -94,6 +94,7 @@ const sortedCubeResults = computed(() => {
                         {{ item.result.lhsValue.toFixed(item.result.isPercentage ? 1 : 0) }}{{ item.result.isPercentage ? '%' : '' }}
                     </template>
                 </span>
+                <div class="spacer" />
             </div>
         </div>
     </div>
@@ -153,5 +154,6 @@ const sortedCubeResults = computed(() => {
 .cube-result-item .pass { color: var(--el-color-success); }
 .cube-result-item .fail { color: var(--el-color-danger); }
 .cube-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.result-value { color: var(--el-text-color-secondary); font-variant-numeric: tabular-nums; margin-left: auto; }
+.result-value { color: var(--el-text-color-secondary); font-variant-numeric: tabular-nums; }
+.spacer { flex: 1; }
 </style>

--- a/src/components/CheckConditionRow.vue
+++ b/src/components/CheckConditionRow.vue
@@ -118,6 +118,8 @@ const sortedCubeResults = computed(() => {
 .condition-header :deep(.el-input-group__append) {
     cursor: pointer;
     user-select: none;
+    min-width: 70px;
+    text-align: center;
 }
 .pass-count {
     display: inline-flex;

--- a/src/components/CheckConditionRow.vue
+++ b/src/components/CheckConditionRow.vue
@@ -94,7 +94,6 @@ const sortedCubeResults = computed(() => {
                         {{ item.result.lhsValue.toFixed(item.result.isPercentage ? 1 : 0) }}{{ item.result.isPercentage ? '%' : '' }}
                     </template>
                 </span>
-                <div class="spacer" />
             </div>
         </div>
     </div>
@@ -143,17 +142,21 @@ const sortedCubeResults = computed(() => {
     overflow-y: auto;
     background: var(--el-fill-color-lighter);
     border-radius: 4px;
+    display: grid;
+    grid-template-columns: 16px 1fr auto;
+    column-gap: 8px;
+    row-gap: 4px;
+    align-items: center;
 }
 .cube-result-item {
-    display: flex;
+    display: grid;
+    grid-template-columns: subgrid;
+    grid-column: 1 / -1;
     align-items: center;
-    gap: 8px;
-    padding: 4px 0;
     font-size: 14px;
 }
 .cube-result-item .pass { color: var(--el-color-success); }
 .cube-result-item .fail { color: var(--el-color-danger); }
 .cube-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.result-value { color: var(--el-text-color-secondary); font-variant-numeric: tabular-nums; }
-.spacer { flex: 1; }
+.result-value { color: var(--el-text-color-secondary); font-variant-numeric: tabular-nums; text-align: right; }
 </style>

--- a/src/components/CheckConditionRow.vue
+++ b/src/components/CheckConditionRow.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue';
 import { useDebounceFn } from '@vueuse/core';
+import { ArrowDown, ArrowRight, Delete, CircleCheck, CircleClose } from '@element-plus/icons-vue';
 import type { CheckCondition, CheckResult } from '../types/checks';
 import { parseCheckExpression } from '../util/CheckExpressionParser';
 
@@ -59,16 +60,17 @@ const sortedCubeResults = computed(() => {
                 placeholder="Enter check expression..."
                 :class="{ 'is-error': parseError }"
                 @input="onInput"
-            >
-                <template #append>
-                    <span class="pass-count" @click="expanded = !expanded">
-                        {{ passCount }}/{{ totalCount }}
-                    </span>
-                </template>
-            </el-input>
-            <el-button type="danger" text @click="$emit('delete')">
-                <el-icon><Delete /></el-icon>
-            </el-button>
+            />
+            <div class="condition-actions">
+                <span class="pass-count">{{ passCount }}/{{ totalCount }}</span>
+                <el-button
+                    class="expand-btn"
+                    text
+                    :icon="expanded ? ArrowDown : ArrowRight"
+                    @click="expanded = !expanded"
+                />
+                <el-button type="danger" text :icon="Delete" @click="$emit('delete')" />
+            </div>
         </div>
         <div v-if="parseError" class="parse-error">
             {{ parseError }}
@@ -104,18 +106,23 @@ const sortedCubeResults = computed(() => {
 .condition-header .el-input {
     flex: 1;
 }
-.condition-header :deep(.el-input-group__append) {
-    cursor: pointer;
-    user-select: none;
-    min-width: 56px;
-    text-align: center;
-    font-weight: 600;
-}
 .condition-header .el-input.is-error :deep(.el-input__wrapper) {
     box-shadow: 0 0 0 1px var(--el-color-danger) inset;
 }
+.condition-actions {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+}
 .pass-count {
     font-variant-numeric: tabular-nums;
+    font-size: 14px;
+    min-width: 40px;
+    text-align: right;
+}
+.expand-btn {
+    padding: 4px;
 }
 .parse-error {
     margin-top: 4px;
@@ -125,9 +132,11 @@ const sortedCubeResults = computed(() => {
 }
 .cube-results-list {
     margin-top: 8px;
-    margin-left: 12px;
+    padding: 8px 12px;
     max-height: 240px;
     overflow-y: auto;
+    background: var(--el-fill-color-lighter);
+    border-radius: 4px;
 }
 .cube-result-item {
     display: flex;

--- a/src/components/CheckConditionRow.vue
+++ b/src/components/CheckConditionRow.vue
@@ -121,14 +121,18 @@ const sortedCubeResults = computed(() => {
     cursor: pointer;
     user-select: none;
     min-width: 70px;
-    text-align: center;
+    padding: 0;
 }
 .pass-count {
-    display: inline-flex;
+    display: flex;
     align-items: center;
+    justify-content: center;
     gap: 6px;
     font-variant-numeric: tabular-nums;
     font-weight: 600;
+    padding: 0 12px;
+    height: 100%;
+    width: 100%;
 }
 .parse-error {
     margin-top: 4px;

--- a/src/components/CheckConditionRow.vue
+++ b/src/components/CheckConditionRow.vue
@@ -18,11 +18,16 @@ const emit = defineEmits<{
 }>();
 
 const localExpression = ref(props.condition.expression);
+const localLabel = ref(props.condition.label ?? '');
 const parseError = ref<string | null>(null);
 const expanded = ref(false);
 
 watch(() => props.condition.expression, (val) => {
   localExpression.value = val;
+});
+
+watch(() => props.condition.label, (val) => {
+  localLabel.value = val ?? '';
 });
 
 const debouncedUpdate = useDebounceFn((val: string) => {
@@ -34,6 +39,11 @@ const debouncedUpdate = useDebounceFn((val: string) => {
 function onInput(val: string) {
   localExpression.value = val;
   debouncedUpdate(val);
+}
+
+function onLabelInput(val: string) {
+  localLabel.value = val;
+  emit('update:label', val);
 }
 
 const passCount = computed(() => {
@@ -58,22 +68,32 @@ const sortedCubeResults = computed(() => {
     <div class="check-condition-row">
         <div class="condition-header">
             <el-input
-                :model-value="localExpression"
-                placeholder="Enter check expression..."
-                :class="{ 'is-error': parseError }"
-                @input="onInput"
+                class="label-input"
+                :model-value="localLabel"
+                placeholder="Label"
+                @update:model-value="onLabelInput"
             >
-                <template #append>
-                    <span class="pass-count" @click="expanded = !expanded">
-                        <el-icon :size="14">
-                            <ArrowDown v-if="expanded" />
-                            <ArrowRight v-else />
-                        </el-icon>
-                        {{ passCount }}/{{ totalCount }}
-                    </span>
-                </template>
+                <template #prepend>Label</template>
             </el-input>
-            <el-button type="danger" text :icon="Delete" @click="$emit('delete')" />
+            <div class="expression-group">
+                <el-input
+                    :model-value="localExpression"
+                    placeholder="Enter check expression..."
+                    :class="{ 'is-error': parseError }"
+                    @input="onInput"
+                >
+                    <template #append>
+                        <span class="pass-count" @click="expanded = !expanded">
+                            <el-icon :size="14">
+                                <ArrowDown v-if="expanded" />
+                                <ArrowRight v-else />
+                            </el-icon>
+                            {{ passCount }}/{{ totalCount }}
+                        </span>
+                    </template>
+                </el-input>
+                <el-button type="danger" text :icon="Delete" @click="$emit('delete')" />
+            </div>
         </div>
         <div v-if="parseError" class="parse-error">
             {{ parseError }}
@@ -104,25 +124,47 @@ const sortedCubeResults = computed(() => {
 
 <style scoped>
 .check-condition-row {
-    margin-bottom: 12px;
+    padding: 12px 0;
+}
+.check-condition-row + .check-condition-row {
+    border-top: 1px solid var(--el-border-color-lighter);
 }
 .condition-header {
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
     gap: 8px;
 }
-.condition-header .el-input {
+.condition-header .label-input {
+    flex: 0 1 200px;
+}
+.expression-group {
+    flex: 1 1 280px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+}
+.expression-group .el-input {
     flex: 1;
+    min-width: 0;
 }
 .condition-header .el-input.is-error :deep(.el-input__wrapper) {
     box-shadow: 0 0 0 1px var(--el-color-danger) inset;
 }
-.condition-header :deep(.el-input-group__append) {
+.condition-header :deep(.el-input-group__append),
+.expression-group :deep(.el-input-group__append) {
     cursor: pointer;
     user-select: none;
     width: 90px;
     flex-shrink: 0;
     padding: 0;
+}
+@media (max-width: 600px) {
+    .condition-header .label-input,
+    .condition-header .expression-group {
+        flex-basis: 100%;
+    }
 }
 .pass-count {
     display: flex;
@@ -141,6 +183,7 @@ const sortedCubeResults = computed(() => {
     color: var(--el-color-danger);
     padding-left: 12px;
 }
+
 .cube-results-list {
     margin-top: 8px;
     padding: 8px 12px;

--- a/src/components/CheckConditionRow.vue
+++ b/src/components/CheckConditionRow.vue
@@ -58,7 +58,6 @@ const sortedCubeResults = computed(() => {
                 :model-value="localExpression"
                 placeholder="Enter check expression..."
                 :class="{ 'is-error': parseError }"
-                size="small"
                 @input="onInput"
             />
             <el-tooltip v-if="parseError" :content="parseError" placement="top">
@@ -68,7 +67,7 @@ const sortedCubeResults = computed(() => {
                 {{ passCount }}/{{ totalCount }}
                 <el-icon :class="{ expanded }"><ArrowRight /></el-icon>
             </span>
-            <el-button size="small" text type="danger" @click="$emit('delete')">
+            <el-button text type="danger" @click="$emit('delete')">
                 <el-icon><Delete /></el-icon>
             </el-button>
         </div>

--- a/src/components/CheckSyntaxDialog.vue
+++ b/src/components/CheckSyntaxDialog.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+defineProps<{ visible: boolean }>();
+defineEmits<{ (e: 'update:visible', val: boolean): void }>();
+</script>
+
+<template>
+    <el-dialog
+        :model-value="visible"
+        title="Check Expression Syntax"
+        width="600px"
+        @update:model-value="$emit('update:visible', $event)"
+    >
+        <div class="syntax-help">
+            <h4>Count Checks</h4>
+            <p>Count cards matching a filter and compare to a threshold.</p>
+            <ul>
+                <li><code>c:u &gt; 10</code> — more than 10 blue cards</li>
+                <li><code>type:creature &gt; 50%</code> — creatures over 50% of cube</li>
+                <li><code>keyword:flying</code> — at least 1 card with flying</li>
+            </ul>
+
+            <h4>Relative Checks</h4>
+            <p>Compare counts of two different filters.</p>
+            <ul>
+                <li><code>t:instant &gt;= t:sorcery</code> — more instants than sorceries</li>
+            </ul>
+
+            <h4>Aggregate Checks</h4>
+            <p>Apply a function over a numeric field. Functions: <code>avg</code>, <code>sum</code>, <code>min</code>, <code>max</code>, <code>median</code>.</p>
+            <p>Fields: <code>cmc</code>, <code>words</code>, <code>power</code>, <code>toughness</code>, <code>elo</code>, <code>usd</code>, <code>tix</code>, <code>year</code>.</p>
+            <ul>
+                <li><code>avg(cmc) &lt; 3.5</code> — average mana value under 3.5</li>
+                <li><code>avg(cmc, type:creature) &lt; 3</code> — average CMC of creatures</li>
+                <li><code>max(cmc) &lt;= 7</code> — no card costs more than 7</li>
+            </ul>
+
+            <h4>Operators</h4>
+            <p><code>&gt;</code> <code>&lt;</code> <code>&gt;=</code> <code>&lt;=</code> <code>=</code> <code>!=</code></p>
+            <p>Operators must have spaces around them. Without an operator, the check defaults to <code>&gt; 0</code>.</p>
+
+            <h4>Card Filter Syntax</h4>
+            <p>The card filter portion uses the same syntax as the Cards tab search (e.g., <code>c:u</code>, <code>type:creature</code>, <code>cmc&gt;3</code>, <code>keyword:flying</code>).</p>
+        </div>
+    </el-dialog>
+</template>
+
+<style scoped>
+.syntax-help h4 {
+  margin-top: 1em;
+  margin-bottom: 0.25em;
+}
+.syntax-help h4:first-child {
+  margin-top: 0;
+}
+.syntax-help code {
+  background: var(--el-fill-color-light);
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+.syntax-help ul {
+  padding-left: 1.5em;
+}
+</style>

--- a/src/components/CubeDetailDialog.vue
+++ b/src/components/CubeDetailDialog.vue
@@ -400,7 +400,7 @@
                                         <CircleCheck v-if="result?.passed" />
                                         <CircleClose v-else-if="result" />
                                     </el-icon>
-                                    <span class="check-expression">{{ condition.expression }}</span>
+                                    <span class="check-expression"><code>{{ condition.expression }}</code></span>
                                     <span v-if="result" class="check-value">
                                         <template v-if="result.expressionType === 'relative'">
                                             {{ result.lhsValue }} vs {{ result.rhsValue }}

--- a/src/components/CubeDetailDialog.vue
+++ b/src/components/CubeDetailDialog.vue
@@ -1576,9 +1576,9 @@ const tokensTabData = computed(() => {
 }
 
 .checks-grid {
-    display: grid;
-    grid-template-columns: 20px auto auto 1fr;
-    column-gap: 12px;
+    display: inline-grid;
+    grid-template-columns: auto auto auto;
+    column-gap: 16px;
     row-gap: 0px;
     align-items: center;
 }
@@ -1588,7 +1588,7 @@ const tokensTabData = computed(() => {
     grid-column: 1 / -1;
     align-items: center;
     font-size: 0.9rem;
-    padding: 4px 6px;
+    padding: 4px 12px;
     border-radius: 4px;
 }
 .check-row:nth-child(odd) {

--- a/src/components/CubeDetailDialog.vue
+++ b/src/components/CubeDetailDialog.vue
@@ -387,6 +387,34 @@
                             </div>
                         </el-col>
 
+                        <el-col :span="24" v-if="activeChecksCollection">
+                            <div class="checks-section">
+                                <div class="checks-header">
+                                    <span class="section-title">Checks</span>
+                                    <span class="checks-summary">
+                                        {{ activeChecksCollection.name }} — {{ checksPassCount }}/{{ cubeCheckResults.length }} passed
+                                    </span>
+                                </div>
+                                <div class="checks-list">
+                                    <div
+                                        v-for="{ condition, result } in cubeCheckResults"
+                                        :key="condition.id"
+                                        class="check-item"
+                                        :class="{ passed: result?.passed, failed: result && !result.passed }"
+                                    >
+                                        <el-icon>
+                                            <CircleCheck v-if="result?.passed" />
+                                            <CircleClose v-else-if="result" />
+                                        </el-icon>
+                                        <span class="check-expression">{{ condition.expression }}</span>
+                                        <span v-if="result" class="check-value">
+                                            {{ result.lhsValue.toFixed(result.isPercentage ? 1 : 0) }}{{ result.isPercentage ? '%' : '' }}
+                                        </span>
+                                    </div>
+                                </div>
+                            </div>
+                        </el-col>
+
                         <el-col :span="24" v-if="activeCube.stats?.graveyardOrderMatters">
                             <div class="graveyard-warning">
                                 ⚠️ This cube contains cards that care about Graveyard Order
@@ -684,11 +712,12 @@
 <script setup lang="ts">
 import { ref, computed, watch, inject, toRef, type Ref } from 'vue';
 import { useDateFormat, useWindowSize } from '@vueuse/core';
-import { Loading, Link, Refresh, Clock, InfoFilled, Delete } from '@element-plus/icons-vue';
+import { Loading, Link, Refresh, Clock, InfoFilled, Delete, CircleCheck, CircleClose } from '@element-plus/icons-vue';
 import { isSnapshot, displayName, externalCubeId, snapshotDateLabel } from '../util/Snapshots';
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
 import type { Cube, CubeCard, SimilarityMatrix } from '../types';
+import type { ChecksState, CheckResult } from '../types/checks';
 import type { ScryfallToken } from '../types/scryfall';
 import { formatPrice } from '../util/HelperFunctions';
 import { getTokens } from '../util/CubeFunctions';
@@ -751,6 +780,8 @@ const openCardDetailDialog = inject<(oracleId: string) => void>('openCardDetailD
 const openCubeDetailDialog = inject<(id: string) => void>('openCubeDetailDialog');
 const refreshCube = inject<(id: string) => Promise<void>>('refreshCube');
 const refreshingCubeIds = inject<Ref<Set<string>>>('refreshingCubeIds', ref(new Set()));
+const checksState = inject<Ref<ChecksState>>('checksState')!;
+const checkResults = inject<Ref<Map<string, Map<string, CheckResult>>>>('checkResults')!;
 const addCube = inject<(id: string, opts?: { refresh?: boolean; hidden?: boolean }) => Promise<void>>('addCube');
 const popDetail = inject<() => void>('popDetail');
 
@@ -765,6 +796,27 @@ const activeCube = computed(() => {
 });
 
 const baseCubeId = computed(() => externalCubeId(activeCube.value ?? { id: '' }));
+
+const activeChecksCollection = computed(() => {
+    const id = checksState.value.activeCollectionId;
+    if (!id) return null;
+    return checksState.value.collections.find(c => c.id === id) ?? null;
+});
+
+const cubeCheckResults = computed(() => {
+    if (!activeCube.value || !activeChecksCollection.value) return [];
+    const cubeId = activeCube.value.id;
+    const cubeMap = checkResults.value.get(cubeId);
+    if (!cubeMap) return [];
+    return activeChecksCollection.value.conditions.map(cond => ({
+        condition: cond,
+        result: cubeMap.get(cond.id),
+    }));
+});
+
+const checksPassCount = computed(() => {
+    return cubeCheckResults.value.filter(r => r.result?.passed).length;
+});
 const currentCubeLoaded = computed(() => !!loadedCubesRef.value[baseCubeId.value]);
 
 const loadingCurrent = ref(false);
@@ -1524,5 +1576,37 @@ const tokensTabData = computed(() => {
     display: flex;
     gap: 0.4rem;
 }
+
+.checks-section {
+    margin-top: 16px;
+}
+.checks-header {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    margin-bottom: 8px;
+}
+.checks-header .section-title {
+    font-weight: 600;
+}
+.checks-summary {
+    font-size: 12px;
+    color: var(--el-text-color-secondary);
+}
+.checks-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+.check-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+}
+.check-item.passed .el-icon { color: var(--el-color-success); }
+.check-item.failed .el-icon { color: var(--el-color-danger); }
+.check-expression { flex: 1; }
+.check-value { color: var(--el-text-color-secondary); }
 
 </style>

--- a/src/components/CubeDetailDialog.vue
+++ b/src/components/CubeDetailDialog.vue
@@ -388,24 +388,22 @@
                         </el-col>
 
                         <el-col :span="24" v-if="activeChecksCollection">
-                            <h4 class="stat-section-title">Checks <span class="checks-collection-name">({{ activeChecksCollection.name }})</span></h4>
+                            <h4 class="stat-section-title">Checks ({{ activeChecksCollection.name }})</h4>
                             <div class="checks-grid">
                                 <div
                                     v-for="{ condition, result } in cubeCheckResults"
                                     :key="condition.id"
-                                    class="check-item"
+                                    class="check-row"
                                     :class="{ passed: result?.passed, failed: result && !result.passed }"
                                 >
-                                    <el-icon :size="18">
+                                    <el-icon :size="20" class="check-icon">
                                         <CircleCheck v-if="result?.passed" />
                                         <CircleClose v-else-if="result" />
                                     </el-icon>
-                                    <div class="check-content">
-                                        <div class="check-expression">{{ condition.expression }}</div>
-                                        <div v-if="result" class="check-detail">
-                                            {{ result.lhsValue.toFixed(result.isPercentage ? 1 : 0) }}{{ result.isPercentage ? '%' : '' }}
-                                        </div>
-                                    </div>
+                                    <span class="check-expression">{{ condition.expression }}</span>
+                                    <span v-if="result" class="check-value">
+                                        {{ result.lhsValue.toFixed(result.isPercentage ? 1 : 0) }}{{ result.isPercentage ? '%' : '' }}
+                                    </span>
                                 </div>
                             </div>
                         </el-col>
@@ -1572,37 +1570,30 @@ const tokensTabData = computed(() => {
     gap: 0.4rem;
 }
 
-.checks-collection-name {
-    font-weight: 400;
-    text-transform: none;
-    letter-spacing: 0;
-    font-size: 0.75rem;
-    color: var(--el-text-color-secondary);
-}
 .checks-grid {
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 8px;
 }
-.check-item {
+.check-row {
     display: flex;
     align-items: center;
-    gap: 10px;
-}
-.check-item.passed .el-icon { color: var(--el-color-success); }
-.check-item.failed .el-icon { color: var(--el-color-danger); }
-.check-content {
-    display: flex;
-    align-items: baseline;
     gap: 12px;
+    font-size: 0.9rem;
+}
+.check-row.passed .check-icon { color: var(--el-color-success); }
+.check-row.failed .check-icon { color: var(--el-color-danger); }
+.check-icon {
+    flex-shrink: 0;
 }
 .check-expression {
-    font-size: 14px;
-    font-family: var(--el-font-family);
+    flex: 1;
     color: var(--el-text-color-primary);
 }
-.check-detail {
-    font-size: 13px;
+.check-value {
+    flex-shrink: 0;
+    min-width: 60px;
+    text-align: right;
     color: var(--el-text-color-secondary);
     font-variant-numeric: tabular-nums;
 }

--- a/src/components/CubeDetailDialog.vue
+++ b/src/components/CubeDetailDialog.vue
@@ -409,7 +409,6 @@
                                             {{ result.lhsValue.toFixed(result.isPercentage ? 1 : 0) }}{{ result.isPercentage ? '%' : '' }}
                                         </template>
                                     </span>
-                                    <div class="check-spacer" />
                                 </div>
                             </div>
                         </el-col>
@@ -1577,14 +1576,17 @@ const tokensTabData = computed(() => {
 }
 
 .checks-grid {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
+    display: grid;
+    grid-template-columns: 20px 1fr auto;
+    column-gap: 12px;
+    row-gap: 8px;
+    align-items: center;
 }
 .check-row {
-    display: flex;
+    display: grid;
+    grid-template-columns: subgrid;
+    grid-column: 1 / -1;
     align-items: center;
-    gap: 12px;
     font-size: 0.9rem;
 }
 .check-row.passed .check-icon { color: var(--el-color-success); }
@@ -1599,12 +1601,9 @@ const tokensTabData = computed(() => {
     color: var(--el-text-color-primary);
 }
 .check-value {
-    flex-shrink: 0;
     color: var(--el-text-color-secondary);
     font-variant-numeric: tabular-nums;
-}
-.check-spacer {
-    flex: 1;
+    text-align: right;
 }
 
 </style>

--- a/src/components/CubeDetailDialog.vue
+++ b/src/components/CubeDetailDialog.vue
@@ -1579,7 +1579,7 @@ const tokensTabData = computed(() => {
     display: grid;
     grid-template-columns: 20px auto auto 1fr;
     column-gap: 12px;
-    row-gap: 8px;
+    row-gap: 0px;
     align-items: center;
 }
 .check-row {

--- a/src/components/CubeDetailDialog.vue
+++ b/src/components/CubeDetailDialog.vue
@@ -1603,6 +1603,8 @@ const tokensTabData = computed(() => {
 .check-value {
     color: var(--el-text-color-secondary);
     font-variant-numeric: tabular-nums;
+    text-align: center;
+    padding-left: 8px;
 }
 
 </style>

--- a/src/components/CubeDetailDialog.vue
+++ b/src/components/CubeDetailDialog.vue
@@ -400,7 +400,10 @@
                                         <CircleCheck v-if="result?.passed" />
                                         <CircleClose v-else-if="result" />
                                     </el-icon>
-                                    <span class="check-expression"><code>{{ condition.expression }}</code></span>
+                                    <el-tooltip v-if="condition.label" :content="condition.expression" placement="top" :hide-after="50" :enterable="false">
+                                        <span class="check-expression">{{ condition.label }}</span>
+                                    </el-tooltip>
+                                    <span v-else class="check-expression"><code>{{ condition.expression }}</code></span>
                                     <span v-if="result" class="check-value">
                                         <template v-if="result.expressionType === 'relative'">
                                             {{ result.lhsValue }} vs {{ result.rhsValue }}

--- a/src/components/CubeDetailDialog.vue
+++ b/src/components/CubeDetailDialog.vue
@@ -401,7 +401,7 @@
                                         <CircleClose v-else-if="result" />
                                     </el-icon>
                                     <el-tooltip v-if="condition.label" :content="condition.expression" placement="top" :hide-after="50" :enterable="false">
-                                        <span class="check-expression">{{ condition.label }}</span>
+                                        <span class="check-expression"><code>{{ condition.label }}</code></span>
                                     </el-tooltip>
                                     <span v-else class="check-expression"><code>{{ condition.expression }}</code></span>
                                     <span v-if="result" class="check-value">

--- a/src/components/CubeDetailDialog.vue
+++ b/src/components/CubeDetailDialog.vue
@@ -406,7 +406,7 @@
                                             {{ result.lhsValue }} vs {{ result.rhsValue }}
                                         </template>
                                         <template v-else>
-                                            {{ result.lhsValue.toFixed(result.isPercentage ? 1 : 0) }}{{ result.isPercentage ? '%' : '' }}
+                                            {{ result.lhsValue.toFixed(result.expressionType === 'aggregate' ? 2 : result.isPercentage ? 1 : 0) }}{{ result.isPercentage ? '%' : '' }}
                                         </template>
                                     </span>
                                 </div>

--- a/src/components/CubeDetailDialog.vue
+++ b/src/components/CubeDetailDialog.vue
@@ -402,7 +402,12 @@
                                     </el-icon>
                                     <span class="check-expression">{{ condition.expression }}</span>
                                     <span v-if="result" class="check-value">
-                                        {{ result.lhsValue.toFixed(result.isPercentage ? 1 : 0) }}{{ result.isPercentage ? '%' : '' }}
+                                        <template v-if="result.expressionType === 'relative'">
+                                            {{ result.lhsValue }} vs {{ result.rhsValue }}
+                                        </template>
+                                        <template v-else>
+                                            {{ result.lhsValue.toFixed(result.isPercentage ? 1 : 0) }}{{ result.isPercentage ? '%' : '' }}
+                                        </template>
                                     </span>
                                 </div>
                             </div>

--- a/src/components/CubeDetailDialog.vue
+++ b/src/components/CubeDetailDialog.vue
@@ -1577,7 +1577,7 @@ const tokensTabData = computed(() => {
 
 .checks-grid {
     display: grid;
-    grid-template-columns: 20px 1fr auto;
+    grid-template-columns: 20px auto auto 1fr;
     column-gap: 12px;
     row-gap: 8px;
     align-items: center;
@@ -1603,7 +1603,6 @@ const tokensTabData = computed(() => {
 .check-value {
     color: var(--el-text-color-secondary);
     font-variant-numeric: tabular-nums;
-    text-align: right;
 }
 
 </style>

--- a/src/components/CubeDetailDialog.vue
+++ b/src/components/CubeDetailDialog.vue
@@ -1588,6 +1588,11 @@ const tokensTabData = computed(() => {
     grid-column: 1 / -1;
     align-items: center;
     font-size: 0.9rem;
+    padding: 4px 6px;
+    border-radius: 4px;
+}
+.check-row:nth-child(odd) {
+    background: var(--el-fill-color-lighter);
 }
 .check-row.passed .check-icon { color: var(--el-color-success); }
 .check-row.failed .check-icon { color: var(--el-color-danger); }

--- a/src/components/CubeDetailDialog.vue
+++ b/src/components/CubeDetailDialog.vue
@@ -1592,13 +1592,14 @@ const tokensTabData = computed(() => {
     flex-shrink: 0;
 }
 .check-expression {
-    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
     color: var(--el-text-color-primary);
 }
 .check-value {
     flex-shrink: 0;
-    min-width: 60px;
-    text-align: right;
+    margin-left: auto;
     color: var(--el-text-color-secondary);
     font-variant-numeric: tabular-nums;
 }

--- a/src/components/CubeDetailDialog.vue
+++ b/src/components/CubeDetailDialog.vue
@@ -388,28 +388,23 @@
                         </el-col>
 
                         <el-col :span="24" v-if="activeChecksCollection">
-                            <div class="checks-section">
-                                <div class="checks-header">
-                                    <span class="section-title">Checks</span>
-                                    <span class="checks-summary">
-                                        {{ activeChecksCollection.name }} — {{ checksPassCount }}/{{ cubeCheckResults.length }} passed
-                                    </span>
-                                </div>
-                                <div class="checks-list">
-                                    <div
-                                        v-for="{ condition, result } in cubeCheckResults"
-                                        :key="condition.id"
-                                        class="check-item"
-                                        :class="{ passed: result?.passed, failed: result && !result.passed }"
-                                    >
-                                        <el-icon>
-                                            <CircleCheck v-if="result?.passed" />
-                                            <CircleClose v-else-if="result" />
-                                        </el-icon>
-                                        <span class="check-expression">{{ condition.expression }}</span>
-                                        <span v-if="result" class="check-value">
+                            <h4 class="stat-section-title">Checks <span class="checks-collection-name">({{ activeChecksCollection.name }})</span></h4>
+                            <div class="checks-grid">
+                                <div
+                                    v-for="{ condition, result } in cubeCheckResults"
+                                    :key="condition.id"
+                                    class="check-item"
+                                    :class="{ passed: result?.passed, failed: result && !result.passed }"
+                                >
+                                    <el-icon :size="18">
+                                        <CircleCheck v-if="result?.passed" />
+                                        <CircleClose v-else-if="result" />
+                                    </el-icon>
+                                    <div class="check-content">
+                                        <div class="check-expression">{{ condition.expression }}</div>
+                                        <div v-if="result" class="check-detail">
                                             {{ result.lhsValue.toFixed(result.isPercentage ? 1 : 0) }}{{ result.isPercentage ? '%' : '' }}
-                                        </span>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
@@ -1577,36 +1572,39 @@ const tokensTabData = computed(() => {
     gap: 0.4rem;
 }
 
-.checks-section {
-    margin-top: 16px;
-}
-.checks-header {
-    display: flex;
-    align-items: baseline;
-    gap: 8px;
-    margin-bottom: 8px;
-}
-.checks-header .section-title {
-    font-weight: 600;
-}
-.checks-summary {
-    font-size: 12px;
+.checks-collection-name {
+    font-weight: 400;
+    text-transform: none;
+    letter-spacing: 0;
+    font-size: 0.75rem;
     color: var(--el-text-color-secondary);
 }
-.checks-list {
+.checks-grid {
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: 10px;
 }
 .check-item {
     display: flex;
     align-items: center;
-    gap: 6px;
-    font-size: 13px;
+    gap: 10px;
 }
 .check-item.passed .el-icon { color: var(--el-color-success); }
 .check-item.failed .el-icon { color: var(--el-color-danger); }
-.check-expression { flex: 1; }
-.check-value { color: var(--el-text-color-secondary); }
+.check-content {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+}
+.check-expression {
+    font-size: 14px;
+    font-family: var(--el-font-family);
+    color: var(--el-text-color-primary);
+}
+.check-detail {
+    font-size: 13px;
+    color: var(--el-text-color-secondary);
+    font-variant-numeric: tabular-nums;
+}
 
 </style>

--- a/src/components/CubeDetailDialog.vue
+++ b/src/components/CubeDetailDialog.vue
@@ -409,6 +409,7 @@
                                             {{ result.lhsValue.toFixed(result.isPercentage ? 1 : 0) }}{{ result.isPercentage ? '%' : '' }}
                                         </template>
                                     </span>
+                                    <div class="check-spacer" />
                                 </div>
                             </div>
                         </el-col>
@@ -1599,9 +1600,11 @@ const tokensTabData = computed(() => {
 }
 .check-value {
     flex-shrink: 0;
-    margin-left: auto;
     color: var(--el-text-color-secondary);
     font-variant-numeric: tabular-nums;
+}
+.check-spacer {
+    flex: 1;
 }
 
 </style>

--- a/src/tabs/ChecksTab.vue
+++ b/src/tabs/ChecksTab.vue
@@ -75,6 +75,7 @@ function getCubeResultsForCondition(conditionId: string) {
                     v-if="checksState.collections.length > 0"
                     :model-value="checksState.activeCollectionId"
                     placeholder="Select collection"
+                    class="collection-select"
                     @update:model-value="checksState.activeCollectionId = $event"
                 >
                     <el-option
@@ -131,6 +132,9 @@ function getCubeResultsForCondition(conditionId: string) {
 
 <style scoped>
 .checks-tab {
+    max-width: 900px;
+    margin: 0 auto;
+    width: 100%;
     padding: 16px;
 }
 .collection-toolbar {
@@ -148,6 +152,9 @@ function getCubeResultsForCondition(conditionId: string) {
     white-space: nowrap;
     font-weight: 500;
 }
+.collection-select {
+    width: 200px;
+}
 .collection-name-input {
     max-width: 220px;
 }
@@ -158,7 +165,7 @@ function getCubeResultsForCondition(conditionId: string) {
     margin-bottom: 12px;
 }
 .conditions-list {
-    max-width: 800px;
+    max-width: 100%;
 }
 .empty-state {
     text-align: center;

--- a/src/tabs/ChecksTab.vue
+++ b/src/tabs/ChecksTab.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, inject } from 'vue';
 import type { Ref, ComputedRef } from 'vue';
+import { Delete } from '@element-plus/icons-vue';
 import type { ChecksState, CheckCollection, CheckResult } from '../types/checks';
 import type { Cube } from '../types/cube';
 import CheckConditionRow from '../components/CheckConditionRow.vue';
@@ -14,6 +15,9 @@ const checksState = inject<Ref<ChecksState>>('checksState')!;
 const checkResults = inject<ComputedRef<Map<string, Map<string, CheckResult>>>>('checkResults')!;
 
 const showSyntaxDialog = ref(false);
+const addDialogVisible = ref(false);
+const addDialogName = ref('');
+const editDialogVisible = ref(false);
 
 const activeCollection = computed<CheckCollection | null>(() => {
   const id = checksState.value.activeCollectionId;
@@ -22,20 +26,29 @@ const activeCollection = computed<CheckCollection | null>(() => {
 });
 
 function createCollection() {
+  const name = addDialogName.value.trim();
+  if (!name) return;
   const newCollection: CheckCollection = {
     id: crypto.randomUUID(),
-    name: 'New Collection',
+    name,
     conditions: [],
   };
   checksState.value.collections.push(newCollection);
   checksState.value.activeCollectionId = newCollection.id;
+  addDialogName.value = '';
+  addDialogVisible.value = false;
 }
 
-function deleteCollection() {
-  const id = checksState.value.activeCollectionId;
-  if (!id) return;
+function deleteCollection(id: string) {
   checksState.value.collections = checksState.value.collections.filter(c => c.id !== id);
-  checksState.value.activeCollectionId = checksState.value.collections[0]?.id ?? null;
+  if (checksState.value.activeCollectionId === id) {
+    checksState.value.activeCollectionId = checksState.value.collections[0]?.id ?? null;
+  }
+}
+
+function renameCollection(id: string, name: string) {
+  const col = checksState.value.collections.find(c => c.id === id);
+  if (col) col.name = name;
 }
 
 function addCondition() {
@@ -67,17 +80,22 @@ function getCubeResultsForCondition(conditionId: string) {
 
 <template>
     <div class="checks-tab">
-        <!-- Collection Management -->
-        <div class="collection-toolbar">
+        <!-- Toolbar (only when collections exist) -->
+        <div v-if="checksState.collections.length > 0" class="collection-toolbar">
             <div class="collection-row">
-                <label class="toolbar-label">Collection</label>
                 <el-select
-                    v-if="checksState.collections.length > 0"
                     :model-value="checksState.activeCollectionId"
                     placeholder="Select collection"
                     class="collection-select"
                     @update:model-value="checksState.activeCollectionId = $event"
                 >
+                    <template #footer>
+                        <div class="collection-select-footer">
+                            <el-button text bg type="success" size="small" @click.stop="addDialogVisible = true">Add</el-button>
+                            <el-divider direction="vertical" />
+                            <el-button text bg size="small" @click.stop="editDialogVisible = true">Edit</el-button>
+                        </div>
+                    </template>
                     <el-option
                         v-for="col in checksState.collections"
                         :key="col.id"
@@ -85,21 +103,7 @@ function getCubeResultsForCondition(conditionId: string) {
                         :value="col.id"
                     />
                 </el-select>
-                <el-input
-                    v-if="activeCollection"
-                    :model-value="activeCollection.name"
-                    class="collection-name-input"
-                    placeholder="Collection name"
-                    @update:model-value="activeCollection!.name = $event"
-                />
-                <el-button @click="createCollection">New</el-button>
-                <el-button
-                    v-if="activeCollection"
-                    type="danger"
-                    @click="deleteCollection"
-                >
-                    Delete
-                </el-button>
+                <div class="toolbar-spacer" />
                 <el-button @click="showSyntaxDialog = true">Syntax Help</el-button>
             </div>
         </div>
@@ -120,11 +124,58 @@ function getCubeResultsForCondition(conditionId: string) {
             </el-button>
         </div>
 
-        <!-- Empty State -->
+        <!-- Empty State (no collections at all) -->
         <div v-else-if="checksState.collections.length === 0" class="empty-state">
             <p>Create a check collection to define conditions cubes should meet.</p>
-            <el-button @click="createCollection">Create Collection</el-button>
+            <el-button @click="addDialogVisible = true">Create Collection</el-button>
         </div>
+
+        <!-- Add Collection Dialog -->
+        <el-dialog
+            v-model="addDialogVisible"
+            title="Add Collection"
+            width="400"
+            align-center
+            destroy-on-close
+        >
+            <el-input
+                v-model="addDialogName"
+                placeholder="Collection name"
+                maxlength="60"
+                show-word-limit
+                @keyup.enter="createCollection"
+            />
+            <template #footer>
+                <el-button @click="addDialogVisible = false">Cancel</el-button>
+                <el-button type="primary" :disabled="!addDialogName.trim()" @click="createCollection">Add</el-button>
+            </template>
+        </el-dialog>
+
+        <!-- Edit Collections Dialog -->
+        <el-dialog
+            v-model="editDialogVisible"
+            title="Edit Collections"
+            width="400"
+            align-center
+            destroy-on-close
+        >
+            <el-empty v-if="checksState.collections.length === 0" description="No collections" :image-size="60" />
+            <ul v-else class="collection-edit-list">
+                <li v-for="col in checksState.collections" :key="col.id" class="collection-edit-item">
+                    <el-input
+                        :model-value="col.name"
+                        size="small"
+                        @update:model-value="renameCollection(col.id, $event)"
+                    />
+                    <el-button link type="danger" @click="deleteCollection(col.id)">
+                        <el-icon><Delete /></el-icon>
+                    </el-button>
+                </li>
+            </ul>
+            <template #footer>
+                <el-button @click="editDialogVisible = false">Close</el-button>
+            </template>
+        </el-dialog>
 
         <CheckSyntaxDialog v-model:visible="showSyntaxDialog" />
     </div>
@@ -144,19 +195,18 @@ function getCubeResultsForCondition(conditionId: string) {
     display: flex;
     align-items: center;
     gap: 10px;
-    flex-wrap: wrap;
-}
-.toolbar-label {
-    font-size: 14px;
-    color: var(--el-text-color-regular);
-    white-space: nowrap;
-    font-weight: 500;
 }
 .collection-select {
     width: 200px;
 }
-.collection-name-input {
-    max-width: 220px;
+.collection-select-footer {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+}
+.toolbar-spacer {
+    flex: 1;
 }
 .conditions-heading {
     font-size: 14px;
@@ -172,5 +222,21 @@ function getCubeResultsForCondition(conditionId: string) {
     padding: 60px 20px;
     color: var(--el-text-color-secondary);
     font-size: 14px;
+}
+.collection-edit-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+.collection-edit-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.collection-edit-item .el-input {
+    flex: 1;
 }
 </style>

--- a/src/tabs/ChecksTab.vue
+++ b/src/tabs/ChecksTab.vue
@@ -73,7 +73,6 @@ function getCubeResultsForCondition(conditionId: string) {
                 v-if="checksState.collections.length > 0"
                 :model-value="checksState.activeCollectionId"
                 placeholder="Select collection"
-                size="small"
                 @update:model-value="checksState.activeCollectionId = $event"
             >
                 <el-option
@@ -86,21 +85,19 @@ function getCubeResultsForCondition(conditionId: string) {
             <el-input
                 v-if="activeCollection"
                 :model-value="activeCollection.name"
-                size="small"
                 class="collection-name-input"
                 @update:model-value="activeCollection!.name = $event"
             />
-            <el-button size="small" @click="createCollection">New Collection</el-button>
+            <el-button @click="createCollection">New Collection</el-button>
             <el-button
                 v-if="activeCollection"
-                size="small"
                 type="danger"
                 text
                 @click="deleteCollection"
             >
                 Delete
             </el-button>
-            <el-button size="small" text @click="showSyntaxDialog = true">
+            <el-button text @click="showSyntaxDialog = true">
                 <el-icon><QuestionFilled /></el-icon>
             </el-button>
         </div>
@@ -115,7 +112,7 @@ function getCubeResultsForCondition(conditionId: string) {
                 @update:expression="updateExpression(index, $event)"
                 @delete="deleteCondition(index)"
             />
-            <el-button size="small" class="add-condition-btn" @click="addCondition">
+            <el-button class="add-condition-btn" @click="addCondition">
                 + Add Condition
             </el-button>
         </div>

--- a/src/tabs/ChecksTab.vue
+++ b/src/tabs/ChecksTab.vue
@@ -68,42 +68,44 @@ function getCubeResultsForCondition(conditionId: string) {
 <template>
     <div class="checks-tab">
         <!-- Collection Management -->
-        <div class="collection-controls">
-            <el-select
-                v-if="checksState.collections.length > 0"
-                :model-value="checksState.activeCollectionId"
-                placeholder="Select collection"
-                @update:model-value="checksState.activeCollectionId = $event"
-            >
-                <el-option
-                    v-for="col in checksState.collections"
-                    :key="col.id"
-                    :label="col.name"
-                    :value="col.id"
+        <div class="collection-toolbar">
+            <div class="collection-row">
+                <label class="toolbar-label">Collection</label>
+                <el-select
+                    v-if="checksState.collections.length > 0"
+                    :model-value="checksState.activeCollectionId"
+                    placeholder="Select collection"
+                    @update:model-value="checksState.activeCollectionId = $event"
+                >
+                    <el-option
+                        v-for="col in checksState.collections"
+                        :key="col.id"
+                        :label="col.name"
+                        :value="col.id"
+                    />
+                </el-select>
+                <el-input
+                    v-if="activeCollection"
+                    :model-value="activeCollection.name"
+                    class="collection-name-input"
+                    placeholder="Collection name"
+                    @update:model-value="activeCollection!.name = $event"
                 />
-            </el-select>
-            <el-input
-                v-if="activeCollection"
-                :model-value="activeCollection.name"
-                class="collection-name-input"
-                @update:model-value="activeCollection!.name = $event"
-            />
-            <el-button @click="createCollection">New Collection</el-button>
-            <el-button
-                v-if="activeCollection"
-                type="danger"
-                text
-                @click="deleteCollection"
-            >
-                Delete
-            </el-button>
-            <el-button text @click="showSyntaxDialog = true">
-                <el-icon><QuestionFilled /></el-icon>
-            </el-button>
+                <el-button @click="createCollection">New</el-button>
+                <el-button
+                    v-if="activeCollection"
+                    type="danger"
+                    @click="deleteCollection"
+                >
+                    Delete
+                </el-button>
+                <el-button @click="showSyntaxDialog = true">Syntax Help</el-button>
+            </div>
         </div>
 
         <!-- Conditions List -->
         <div v-if="activeCollection" class="conditions-list">
+            <h4 class="conditions-heading">Conditions</h4>
             <CheckConditionRow
                 v-for="(condition, index) in activeCollection.conditions"
                 :key="condition.id"
@@ -112,7 +114,7 @@ function getCubeResultsForCondition(conditionId: string) {
                 @update:expression="updateExpression(index, $event)"
                 @delete="deleteCondition(index)"
             />
-            <el-button class="add-condition-btn" @click="addCondition">
+            <el-button @click="addCondition">
                 + Add Condition
             </el-button>
         </div>
@@ -129,27 +131,39 @@ function getCubeResultsForCondition(conditionId: string) {
 
 <style scoped>
 .checks-tab {
-  padding: 16px;
+    padding: 16px;
 }
-.collection-controls {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-bottom: 16px;
-  flex-wrap: wrap;
+.collection-toolbar {
+    margin-bottom: 20px;
+}
+.collection-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+.toolbar-label {
+    font-size: 14px;
+    color: var(--el-text-color-regular);
+    white-space: nowrap;
+    font-weight: 500;
 }
 .collection-name-input {
-  max-width: 200px;
+    max-width: 220px;
+}
+.conditions-heading {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--el-text-color-regular);
+    margin-bottom: 12px;
 }
 .conditions-list {
-  max-width: 800px;
-}
-.add-condition-btn {
-  margin-top: 8px;
+    max-width: 800px;
 }
 .empty-state {
-  text-align: center;
-  padding: 40px;
-  color: var(--el-text-color-secondary);
+    text-align: center;
+    padding: 60px 20px;
+    color: var(--el-text-color-secondary);
+    font-size: 14px;
 }
 </style>

--- a/src/tabs/ChecksTab.vue
+++ b/src/tabs/ChecksTab.vue
@@ -31,7 +31,7 @@ function createCollection() {
   const newCollection: CheckCollection = {
     id: crypto.randomUUID(),
     name,
-    conditions: [],
+    conditions: [{ id: crypto.randomUUID(), expression: '' }],
   };
   checksState.value.collections.push(newCollection);
   checksState.value.activeCollectionId = newCollection.id;

--- a/src/tabs/ChecksTab.vue
+++ b/src/tabs/ChecksTab.vue
@@ -69,6 +69,11 @@ function updateExpression(index: number, value: string) {
   activeCollection.value.conditions[index].expression = value;
 }
 
+function updateLabel(index: number, value: string) {
+  if (!activeCollection.value) return;
+  activeCollection.value.conditions[index].label = value || undefined;
+}
+
 function getCubeResultsForCondition(conditionId: string) {
   return Object.entries(props.loadedCubes).map(([cubeId, cube]) => ({
     cubeId,
@@ -118,6 +123,7 @@ function getCubeResultsForCondition(conditionId: string) {
                 :condition="condition"
                 :cube-results="getCubeResultsForCondition(condition.id)"
                 @update:expression="updateExpression(index, $event)"
+                @update:label="updateLabel(index, $event)"
                 @delete="deleteCondition(index)"
             />
             <el-button @click="addCondition">
@@ -187,7 +193,6 @@ function getCubeResultsForCondition(conditionId: string) {
     max-width: 900px;
     margin: 0 auto;
     width: 100%;
-    padding: 16px;
 }
 .collection-toolbar {
     margin-bottom: 20px;
@@ -195,6 +200,7 @@ function getCubeResultsForCondition(conditionId: string) {
 .collection-row {
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
     gap: 10px;
 }
 .collection-select {

--- a/src/tabs/ChecksTab.vue
+++ b/src/tabs/ChecksTab.vue
@@ -1,0 +1,158 @@
+<script setup lang="ts">
+import { ref, computed, inject } from 'vue';
+import type { Ref, ComputedRef } from 'vue';
+import type { ChecksState, CheckCollection, CheckResult } from '../types/checks';
+import type { Cube } from '../types/cube';
+import CheckConditionRow from '../components/CheckConditionRow.vue';
+import CheckSyntaxDialog from '../components/CheckSyntaxDialog.vue';
+
+const props = defineProps<{
+  loadedCubes: Record<string, Cube>;
+}>();
+
+const checksState = inject<Ref<ChecksState>>('checksState')!;
+const checkResults = inject<ComputedRef<Map<string, Map<string, CheckResult>>>>('checkResults')!;
+
+const showSyntaxDialog = ref(false);
+
+const activeCollection = computed<CheckCollection | null>(() => {
+  const id = checksState.value.activeCollectionId;
+  if (!id) return null;
+  return checksState.value.collections.find(c => c.id === id) ?? null;
+});
+
+function createCollection() {
+  const newCollection: CheckCollection = {
+    id: crypto.randomUUID(),
+    name: 'New Collection',
+    conditions: [],
+  };
+  checksState.value.collections.push(newCollection);
+  checksState.value.activeCollectionId = newCollection.id;
+}
+
+function deleteCollection() {
+  const id = checksState.value.activeCollectionId;
+  if (!id) return;
+  checksState.value.collections = checksState.value.collections.filter(c => c.id !== id);
+  checksState.value.activeCollectionId = checksState.value.collections[0]?.id ?? null;
+}
+
+function addCondition() {
+  if (!activeCollection.value) return;
+  activeCollection.value.conditions.push({
+    id: crypto.randomUUID(),
+    expression: '',
+  });
+}
+
+function deleteCondition(index: number) {
+  if (!activeCollection.value) return;
+  activeCollection.value.conditions.splice(index, 1);
+}
+
+function updateExpression(index: number, value: string) {
+  if (!activeCollection.value) return;
+  activeCollection.value.conditions[index].expression = value;
+}
+
+function getCubeResultsForCondition(conditionId: string) {
+  return Object.entries(props.loadedCubes).map(([cubeId, cube]) => ({
+    cubeId,
+    cubeName: cube.name,
+    result: checkResults.value.get(cubeId)?.get(conditionId),
+  }));
+}
+</script>
+
+<template>
+    <div class="checks-tab">
+        <!-- Collection Management -->
+        <div class="collection-controls">
+            <el-select
+                v-if="checksState.collections.length > 0"
+                :model-value="checksState.activeCollectionId"
+                placeholder="Select collection"
+                size="small"
+                @update:model-value="checksState.activeCollectionId = $event"
+            >
+                <el-option
+                    v-for="col in checksState.collections"
+                    :key="col.id"
+                    :label="col.name"
+                    :value="col.id"
+                />
+            </el-select>
+            <el-input
+                v-if="activeCollection"
+                :model-value="activeCollection.name"
+                size="small"
+                class="collection-name-input"
+                @update:model-value="activeCollection!.name = $event"
+            />
+            <el-button size="small" @click="createCollection">New Collection</el-button>
+            <el-button
+                v-if="activeCollection"
+                size="small"
+                type="danger"
+                text
+                @click="deleteCollection"
+            >
+                Delete
+            </el-button>
+            <el-button size="small" text @click="showSyntaxDialog = true">
+                <el-icon><QuestionFilled /></el-icon>
+            </el-button>
+        </div>
+
+        <!-- Conditions List -->
+        <div v-if="activeCollection" class="conditions-list">
+            <CheckConditionRow
+                v-for="(condition, index) in activeCollection.conditions"
+                :key="condition.id"
+                :condition="condition"
+                :cube-results="getCubeResultsForCondition(condition.id)"
+                @update:expression="updateExpression(index, $event)"
+                @delete="deleteCondition(index)"
+            />
+            <el-button size="small" class="add-condition-btn" @click="addCondition">
+                + Add Condition
+            </el-button>
+        </div>
+
+        <!-- Empty State -->
+        <div v-else-if="checksState.collections.length === 0" class="empty-state">
+            <p>Create a check collection to define conditions cubes should meet.</p>
+            <el-button @click="createCollection">Create Collection</el-button>
+        </div>
+
+        <CheckSyntaxDialog v-model:visible="showSyntaxDialog" />
+    </div>
+</template>
+
+<style scoped>
+.checks-tab {
+  padding: 16px;
+}
+.collection-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+.collection-name-input {
+  max-width: 200px;
+}
+.conditions-list {
+  max-width: 800px;
+}
+.add-condition-btn {
+  margin-top: 8px;
+}
+.empty-state {
+  text-align: center;
+  padding: 40px;
+  color: var(--el-text-color-secondary);
+}
+</style>

--- a/src/tabs/ChecksTab.vue
+++ b/src/tabs/ChecksTab.vue
@@ -85,7 +85,8 @@ function getCubeResultsForCondition(conditionId: string) {
             <div class="collection-row">
                 <el-select
                     :model-value="checksState.activeCollectionId"
-                    placeholder="Select collection"
+                    label="Collections"
+                    placeholder="Collections..."
                     class="collection-select"
                     @update:model-value="checksState.activeCollectionId = $event"
                 >

--- a/src/tabs/ChecksTab.vue
+++ b/src/tabs/ChecksTab.vue
@@ -126,6 +126,7 @@ function getCubeResultsForCondition(conditionId: string) {
                 @update:label="updateLabel(index, $event)"
                 @delete="deleteCondition(index)"
             />
+            <el-divider />
             <el-button @click="addCondition">
                 + Add Condition
             </el-button>

--- a/src/tabs/OverviewTab.vue
+++ b/src/tabs/OverviewTab.vue
@@ -424,6 +424,10 @@
                 <StatCmpIndicator v-if="showPeerComparisons" :comparison="rowCmp(row.stats.cardCounts.supplementalProduct / row.stats.totalCards, 'supplementalProductRatio')" />
             </template>
 
+            <template #cell-checks="{ row }">
+                {{ getChecksPassCount(row.id) }}/{{ activeCheckCount }}
+            </template>
+
             <template #cell-avgSimilarityScore="{ row }">
                 {{ (row.avgSimilarityScore * 100).toFixed(2) }}%
                 <StatCmpIndicator v-if="showPeerComparisons" :comparison="rowCmp(row.avgSimilarityScore, 'avgSimilarityScore')" />
@@ -483,7 +487,7 @@
 
 <script setup lang="ts">
 import { ref, reactive, computed, inject, watch } from 'vue';
-import type { Ref } from 'vue';
+import type { Ref, ComputedRef } from 'vue';
 import { useBackDismiss } from '../util/useBackDismiss';
 import { ElMessage, ElMessageBox } from 'element-plus';
 import { getNestedProp, castInensitiveSort, formatPrice, normalizeSortName } from '../util/HelperFunctions';
@@ -500,6 +504,7 @@ import { parseQuery } from '../util/CardFilterParser';
 import { displayName, isSnapshot, externalCubeId } from '../util/Snapshots';
 import { evaluateCubeFilter, extractCubeSortDirective } from '../util/CubeFilterEvaluator';
 import type { CubeFilterContext } from '../util/CubeFilterEvaluator';
+import type { ChecksState, CheckResult } from '../types/checks';
 
 const { width: windowWidth } = useWindowSize();
 const isMobile = computed(() => windowWidth.value <= 760);
@@ -627,6 +632,21 @@ const loadingProgressPercent = computed(() => {
 
 const openCubeDetailDialog = inject('openCubeDetailDialog');
 const refreshingCubeIds = inject<Ref<Set<string>>>('refreshingCubeIds', ref(new Set()));
+const checksState = inject<Ref<ChecksState>>('checksState')!;
+const checkResults = inject<ComputedRef<Map<string, Map<string, CheckResult>>>>('checkResults')!;
+
+const activeCheckCount = computed(() => {
+    const id = checksState.value.activeCollectionId;
+    if (!id) return 0;
+    const collection = checksState.value.collections.find(c => c.id === id);
+    return collection?.conditions.length ?? 0;
+});
+
+function getChecksPassCount(cubeId: string): number {
+    const cubeMap = checkResults.value.get(cubeId);
+    if (!cubeMap) return 0;
+    return [...cubeMap.values()].filter(r => r.passed).length;
+}
 
 const submitAddCubeForm = async () => {
     addCubeForm.loading = true;
@@ -795,6 +815,12 @@ const columnOptions = ref([
             { value: 'stats.cardCounts.supplementalProduct', label: "Supplemental Product", tooltip: "Cards originally from Supplemental Products (includes Portal)" },
         ],
     },
+    {
+        label: 'Checks',
+        options: [
+            { value: 'checks', label: 'Checks', tooltip: 'Number of passing checks from the active check collection' },
+        ],
+    },
 ]);
 
 // --- Sort state ---
@@ -884,6 +910,7 @@ const tableColumns = computed<StickyTableColumn[]>(() => [
     { key: 'removal', prop: 'stats.cardCounts.removal', label: 'Removal', minWidth: '70px', sortable: true, tooltip: "Cards tagged as 'removal' in Scryfall's Tagger", visible: config.value.visibleColumns.includes('stats.cardCounts.removal') },
     { key: 'universesBeyond', prop: 'stats.cardCounts.universesBeyond', label: 'UB', minWidth: '55px', sortable: true, tooltip: 'Universes Beyond — cards originally from non-Magic IP products (includes Standard sets)', visible: config.value.visibleColumns.includes('stats.cardCounts.universesBeyond') },
     { key: 'supplementalProduct', prop: 'stats.cardCounts.supplementalProduct', label: 'Supp.', minWidth: '60px', sortable: true, tooltip: 'Supplemental Product — cards originally from supplemental products (includes Portal)', visible: config.value.visibleColumns.includes('stats.cardCounts.supplementalProduct') },
+    { key: 'checks', prop: 'checksPassCount', label: 'Checks', minWidth: '70px', sortable: true, tooltip: 'Checks passed / total from active collection', visible: config.value.visibleColumns.includes('checks') },
 ]);
 
 // --- Filtered + sorted data ---
@@ -899,7 +926,7 @@ const filteredData = computed(() => {
 
     return data.filter(cube => {
         const cards = props.loadedCubes[cube.id]?.cards || [];
-        const ctx: CubeFilterContext = { cards };
+        const ctx: CubeFilterContext = { cards, checksPassCount: getChecksPassCount(cube.id) };
         return evaluateCubeFilter(parsedCubeQuery.value.ast, cube, ctx);
     });
 });
@@ -910,6 +937,14 @@ const sortedData = computed(() => {
     const dir = resolvedSortDirection.value === 'ascending' ? 1 : -1;
 
     return data.sort((a, b) => {
+        // Checks sort (virtual property, not on the cube object)
+        if (prop === 'checksPassCount') {
+            const aVal = getChecksPassCount(a.id);
+            const bVal = getChecksPassCount(b.id);
+            if (aVal !== bVal) return (aVal - bVal) * dir;
+            return castInensitiveSort(normalizeSortName(a.name), normalizeSortName(b.name));
+        }
+
         // Use ratioSort for newCards and cardCounts ratios
         if (prop === 'stats.newCards' || prop.startsWith('stats.cardCounts.')) {
             const aRatio = getNestedProp(a, prop) / a.stats.totalCards;

--- a/src/tabs/OverviewTab.vue
+++ b/src/tabs/OverviewTab.vue
@@ -266,15 +266,19 @@
                     <div class="cube-tile-stats">
                         <span class="cube-tile-stat">
                             <el-text size="small" tag="b">{{ row.stats.totalCards }}</el-text>
-                            <el-text size="small" type="info"> cards</el-text>
+                            <el-text size="small" type="info">&nbsp;cards</el-text>
                         </span>
                         <span class="cube-tile-stat">
                             <el-text size="small" tag="b">{{ (row.stats.averageNonLandCmc ?? 0).toFixed(2) }}</el-text>
-                            <el-text size="small" type="info"> avg MV</el-text>
+                            <el-text size="small" type="info">&nbsp;avg MV</el-text>
+                        </span>
+                        <span v-if="activeCheckCount > 0" class="cube-tile-stat">
+                            <el-text size="small" tag="b">{{ getChecksPassCount(row.id) }}/{{ activeCheckCount }}</el-text>
+                            <el-text size="small" type="info">&nbsp;checks</el-text>
                         </span>
                         <span v-if="sortedData.length > 1" class="cube-tile-stat">
                             <el-text size="small" tag="b">{{ (row.avgSimilarityScore * 100).toFixed(1) }}%</el-text>
-                            <el-text size="small" type="info"> similarity</el-text>
+                            <el-text size="small" type="info">&nbsp;similarity</el-text>
                         </span>
                     </div>
                 </div>

--- a/src/types/checks.ts
+++ b/src/types/checks.ts
@@ -50,4 +50,5 @@ export interface CheckResult {
   lhsValue: number;
   rhsValue: number;
   isPercentage: boolean;
+  expressionType: CheckExpression['type'];
 }

--- a/src/types/checks.ts
+++ b/src/types/checks.ts
@@ -1,0 +1,53 @@
+export type ComparisonOp = '>' | '<' | '>=' | '<=' | '!=' | '=';
+export type AggregateFunction = 'avg' | 'sum' | 'min' | 'max' | 'median';
+export type AggregateField = 'cmc' | 'words' | 'power' | 'toughness' | 'elo' | 'usd' | 'tix' | 'year';
+
+export interface CountCheck {
+  type: 'count';
+  cardFilter: string;
+  op: ComparisonOp;
+  threshold: number;
+  isPercentage: boolean;
+}
+
+export interface RelativeCheck {
+  type: 'relative';
+  lhsFilter: string;
+  op: ComparisonOp;
+  rhsFilter: string;
+}
+
+export interface AggregateCheck {
+  type: 'aggregate';
+  func: AggregateFunction;
+  field: AggregateField;
+  cardFilter: string | null;
+  op: ComparisonOp;
+  threshold: number;
+}
+
+export type CheckExpression = CountCheck | RelativeCheck | AggregateCheck;
+
+export interface CheckCondition {
+  id: string;
+  expression: string;
+  label?: string;
+}
+
+export interface CheckCollection {
+  id: string;
+  name: string;
+  conditions: CheckCondition[];
+}
+
+export interface ChecksState {
+  collections: CheckCollection[];
+  activeCollectionId: string | null;
+}
+
+export interface CheckResult {
+  passed: boolean;
+  lhsValue: number;
+  rhsValue: number;
+  isPercentage: boolean;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,4 +3,5 @@ export type * from './scryfall';
 export type * from './cube';
 export type * from './cubecobra';
 export type * from './presets';
+export type * from './checks';
 export type { ArchetypeResult } from '../util/ArchetypeDetection';

--- a/src/util/CheckEvaluator.test.ts
+++ b/src/util/CheckEvaluator.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateCheck } from './CheckEvaluator';
+import type { CountCheck, RelativeCheck, AggregateCheck } from '../types/checks';
+import type { CubeCard } from '../types/cube';
+
+function makeCard(overrides: Partial<CubeCard> = {}): CubeCard {
+  return {
+    printingId: 'test-print',
+    oracleId: 'test-oracle',
+    name: 'Test Card',
+    cmc: 3,
+    colors: ['U'],
+    effectiveColors: ['U'],
+    typeLine: 'Creature — Human',
+    effectiveTypes: ['creature'],
+    primaryType: 'creature',
+    oracleText: 'some oracle text here',
+    oracleTextWordCount: 4,
+    rarity: 'common',
+    keywords: [],
+    ...overrides,
+  } as CubeCard;
+}
+
+const emptyCtx = { loadedCubes: {} };
+
+describe('CheckEvaluator', () => {
+  describe('count checks', () => {
+    it('counts matching cards (absolute)', () => {
+      const cards = [
+        makeCard({ colors: ['U'], effectiveColors: ['U'], typeLine: 'Creature', effectiveTypes: ['creature'] }),
+        makeCard({ colors: ['U'], effectiveColors: ['U'], typeLine: 'Instant', effectiveTypes: ['instant'] }),
+        makeCard({ colors: ['R'], effectiveColors: ['R'], typeLine: 'Creature', effectiveTypes: ['creature'] }),
+      ];
+      const expr: CountCheck = {
+        type: 'count',
+        cardFilter: 'c:u',
+        op: '>',
+        threshold: 1,
+        isPercentage: false,
+      };
+      const result = evaluateCheck(expr, cards, emptyCtx);
+      expect(result.passed).toBe(true);
+      expect(result.lhsValue).toBe(2);
+      expect(result.rhsValue).toBe(1);
+    });
+
+    it('counts matching cards (percentage)', () => {
+      const cards = [
+        makeCard({ typeLine: 'Creature', effectiveTypes: ['creature'] }),
+        makeCard({ typeLine: 'Creature', effectiveTypes: ['creature'] }),
+        makeCard({ typeLine: 'Instant', effectiveTypes: ['instant'] }),
+        makeCard({ typeLine: 'Land', effectiveTypes: ['land'] }),
+      ];
+      const expr: CountCheck = {
+        type: 'count',
+        cardFilter: 'type:creature',
+        op: '>',
+        threshold: 50,
+        isPercentage: true,
+      };
+      const result = evaluateCheck(expr, cards, emptyCtx);
+      // 2/4 = 50%, not > 50%
+      expect(result.passed).toBe(false);
+      expect(result.lhsValue).toBe(50);
+      expect(result.rhsValue).toBe(50);
+    });
+
+    it('handles implicit > 0 (at least one match)', () => {
+      const cards = [
+        makeCard({ keywords: ['flying'] }),
+        makeCard({ keywords: [] }),
+      ];
+      const expr: CountCheck = {
+        type: 'count',
+        cardFilter: 'keyword:flying',
+        op: '>',
+        threshold: 0,
+        isPercentage: false,
+      };
+      const result = evaluateCheck(expr, cards, emptyCtx);
+      expect(result.passed).toBe(true);
+      expect(result.lhsValue).toBe(1);
+    });
+  });
+
+  describe('relative checks', () => {
+    it('compares counts of two filters', () => {
+      const cards = [
+        makeCard({ typeLine: 'Instant', effectiveTypes: ['instant'] }),
+        makeCard({ typeLine: 'Instant', effectiveTypes: ['instant'] }),
+        makeCard({ typeLine: 'Sorcery', effectiveTypes: ['sorcery'] }),
+      ];
+      const expr: RelativeCheck = {
+        type: 'relative',
+        lhsFilter: 't:instant',
+        op: '>=',
+        rhsFilter: 't:sorcery',
+      };
+      const result = evaluateCheck(expr, cards, emptyCtx);
+      expect(result.passed).toBe(true);
+      expect(result.lhsValue).toBe(2);
+      expect(result.rhsValue).toBe(1);
+    });
+  });
+
+  describe('aggregate checks', () => {
+    it('computes average over all cards', () => {
+      const cards = [
+        makeCard({ cmc: 2 }),
+        makeCard({ cmc: 4 }),
+        makeCard({ cmc: 6 }),
+      ];
+      const expr: AggregateCheck = {
+        type: 'aggregate',
+        func: 'avg',
+        field: 'cmc',
+        cardFilter: null,
+        op: '<',
+        threshold: 5,
+      };
+      const result = evaluateCheck(expr, cards, emptyCtx);
+      expect(result.passed).toBe(true);
+      expect(result.lhsValue).toBe(4); // (2+4+6)/3
+    });
+
+    it('computes scoped average', () => {
+      const cards = [
+        makeCard({ cmc: 2, typeLine: 'Creature', effectiveTypes: ['creature'] }),
+        makeCard({ cmc: 6, typeLine: 'Creature', effectiveTypes: ['creature'] }),
+        makeCard({ cmc: 10, typeLine: 'Instant', effectiveTypes: ['instant'] }),
+      ];
+      const expr: AggregateCheck = {
+        type: 'aggregate',
+        func: 'avg',
+        field: 'cmc',
+        cardFilter: 'type:creature',
+        op: '<=',
+        threshold: 4,
+      };
+      const result = evaluateCheck(expr, cards, emptyCtx);
+      expect(result.passed).toBe(true);
+      expect(result.lhsValue).toBe(4); // (2+6)/2
+    });
+
+    it('computes median', () => {
+      const cards = [
+        makeCard({ cmc: 1 }),
+        makeCard({ cmc: 3 }),
+        makeCard({ cmc: 7 }),
+        makeCard({ cmc: 9 }),
+        makeCard({ cmc: 10 }),
+      ];
+      const expr: AggregateCheck = {
+        type: 'aggregate',
+        func: 'median',
+        field: 'cmc',
+        cardFilter: null,
+        op: '=',
+        threshold: 7,
+      };
+      const result = evaluateCheck(expr, cards, emptyCtx);
+      expect(result.passed).toBe(true);
+      expect(result.lhsValue).toBe(7);
+    });
+
+    it('skips cards with non-numeric values for power', () => {
+      const cards = [
+        makeCard({ power: '2' } as any),
+        makeCard({ power: '*' } as any),
+        makeCard({ power: '4' } as any),
+      ];
+      const expr: AggregateCheck = {
+        type: 'aggregate',
+        func: 'avg',
+        field: 'power',
+        cardFilter: null,
+        op: '=',
+        threshold: 3,
+      };
+      const result = evaluateCheck(expr, cards, emptyCtx);
+      expect(result.passed).toBe(true);
+      expect(result.lhsValue).toBe(3); // (2+4)/2, * skipped
+    });
+  });
+});

--- a/src/util/CheckEvaluator.ts
+++ b/src/util/CheckEvaluator.ts
@@ -1,0 +1,127 @@
+import type { CheckExpression, CheckResult, AggregateField } from '../types/checks';
+import type { CubeCard } from '../types/cube';
+import type { FilterContext } from './CardFilterEvaluator';
+import { evaluateCard } from './CardFilterEvaluator';
+import { parseQuery } from './CardFilterParser';
+
+function compare(lhs: number, op: string, rhs: number): boolean {
+  switch (op) {
+    case '>':  return lhs > rhs;
+    case '<':  return lhs < rhs;
+    case '>=': return lhs >= rhs;
+    case '<=': return lhs <= rhs;
+    case '!=': return lhs !== rhs;
+    case '=':  return lhs === rhs;
+    default:   return false;
+  }
+}
+
+function countMatching(cardFilter: string, cards: CubeCard[], ctx: FilterContext): number {
+  const { ast } = parseQuery(cardFilter);
+  if (!ast) return 0;
+  return cards.filter(card => evaluateCard(ast, card, ctx)).length;
+}
+
+function getNumericField(card: CubeCard, field: AggregateField): number | null {
+  switch (field) {
+    case 'cmc':
+      return card.cmc ?? null;
+    case 'words':
+      return card.oracleTextWordCount ?? null;
+    case 'power': {
+      const v = parseFloat((card as any).power);
+      return isNaN(v) ? null : v;
+    }
+    case 'toughness': {
+      const v = parseFloat((card as any).toughness);
+      return isNaN(v) ? null : v;
+    }
+    case 'elo':
+      return card.elo ?? null;
+    case 'usd':
+      return card.minPriceUsd ?? null;
+    case 'tix':
+      return card.minPriceTix ?? null;
+    case 'year':
+      return card.releaseYear ?? null;
+    default:
+      return null;
+  }
+}
+
+function computeAggregate(func: string, values: number[]): number | null {
+  if (values.length === 0) return null;
+  switch (func) {
+    case 'avg':
+      return values.reduce((a, b) => a + b, 0) / values.length;
+    case 'sum':
+      return values.reduce((a, b) => a + b, 0);
+    case 'min':
+      return Math.min(...values);
+    case 'max':
+      return Math.max(...values);
+    case 'median': {
+      const sorted = [...values].sort((a, b) => a - b);
+      const mid = Math.floor(sorted.length / 2);
+      return sorted.length % 2 === 0
+        ? (sorted[mid - 1] + sorted[mid]) / 2
+        : sorted[mid];
+    }
+    default:
+      return null;
+  }
+}
+
+export function evaluateCheck(expression: CheckExpression, cards: CubeCard[], ctx: FilterContext): CheckResult {
+  switch (expression.type) {
+    case 'count': {
+      const matchCount = countMatching(expression.cardFilter, cards, ctx);
+      const totalCards = cards.length;
+      let lhsValue: number;
+      if (expression.isPercentage) {
+        lhsValue = totalCards > 0 ? (matchCount / totalCards) * 100 : 0;
+      } else {
+        lhsValue = matchCount;
+      }
+      return {
+        passed: compare(lhsValue, expression.op, expression.threshold),
+        lhsValue,
+        rhsValue: expression.threshold,
+        isPercentage: expression.isPercentage,
+      };
+    }
+
+    case 'relative': {
+      const lhsCount = countMatching(expression.lhsFilter, cards, ctx);
+      const rhsCount = countMatching(expression.rhsFilter, cards, ctx);
+      return {
+        passed: compare(lhsCount, expression.op, rhsCount),
+        lhsValue: lhsCount,
+        rhsValue: rhsCount,
+        isPercentage: false,
+      };
+    }
+
+    case 'aggregate': {
+      let scopedCards = cards;
+      if (expression.cardFilter) {
+        const { ast } = parseQuery(expression.cardFilter);
+        if (ast) {
+          scopedCards = cards.filter(card => evaluateCard(ast, card, ctx));
+        }
+      }
+      const values: number[] = [];
+      for (const card of scopedCards) {
+        const v = getNumericField(card, expression.field);
+        if (v !== null) values.push(v);
+      }
+      const aggResult = computeAggregate(expression.func, values) ?? 0;
+      return {
+        passed: compare(aggResult, expression.op, expression.threshold),
+        lhsValue: aggResult,
+        rhsValue: expression.threshold,
+        isPercentage: false,
+      };
+    }
+  }
+}

--- a/src/util/CheckEvaluator.ts
+++ b/src/util/CheckEvaluator.ts
@@ -88,6 +88,7 @@ export function evaluateCheck(expression: CheckExpression, cards: CubeCard[], ct
         lhsValue,
         rhsValue: expression.threshold,
         isPercentage: expression.isPercentage,
+        expressionType: 'count',
       };
     }
 
@@ -99,6 +100,7 @@ export function evaluateCheck(expression: CheckExpression, cards: CubeCard[], ct
         lhsValue: lhsCount,
         rhsValue: rhsCount,
         isPercentage: false,
+        expressionType: 'relative',
       };
     }
 
@@ -121,6 +123,7 @@ export function evaluateCheck(expression: CheckExpression, cards: CubeCard[], ct
         lhsValue: aggResult,
         rhsValue: expression.threshold,
         isPercentage: false,
+        expressionType: 'aggregate',
       };
     }
   }

--- a/src/util/CheckEvaluator.ts
+++ b/src/util/CheckEvaluator.ts
@@ -16,10 +16,14 @@ function compare(lhs: number, op: string, rhs: number): boolean {
   }
 }
 
+function toEvaluatorRow(card: CubeCard): any {
+  return { ...card, effectiveColors: card.colors, effectiveColorIdentity: card.colorIdentity };
+}
+
 function countMatching(cardFilter: string, cards: CubeCard[], ctx: FilterContext): number {
   const { ast } = parseQuery(cardFilter);
   if (!ast) return 0;
-  return cards.filter(card => evaluateCard(ast, card, ctx)).length;
+  return cards.filter(card => evaluateCard(ast, toEvaluatorRow(card), ctx)).length;
 }
 
 function getNumericField(card: CubeCard, field: AggregateField): number | null {
@@ -109,7 +113,7 @@ export function evaluateCheck(expression: CheckExpression, cards: CubeCard[], ct
       if (expression.cardFilter) {
         const { ast } = parseQuery(expression.cardFilter);
         if (ast) {
-          scopedCards = cards.filter(card => evaluateCard(ast, card, ctx));
+          scopedCards = cards.filter(card => evaluateCard(ast, toEvaluatorRow(card), ctx));
         }
       }
       const values: number[] = [];

--- a/src/util/CheckExpressionParser.test.ts
+++ b/src/util/CheckExpressionParser.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest';
+import { parseCheckExpression } from './CheckExpressionParser';
+
+describe('CheckExpressionParser', () => {
+  describe('count checks', () => {
+    it('parses absolute count: c:u > 10', () => {
+      const result = parseCheckExpression('c:u > 10');
+      expect(result.error).toBeNull();
+      expect(result.expression).toEqual({
+        type: 'count',
+        cardFilter: 'c:u',
+        op: '>',
+        threshold: 10,
+        isPercentage: false,
+      });
+    });
+
+    it('parses percentage count: type:creature > 50%', () => {
+      const result = parseCheckExpression('type:creature > 50%');
+      expect(result.error).toBeNull();
+      expect(result.expression).toEqual({
+        type: 'count',
+        cardFilter: 'type:creature',
+        op: '>',
+        threshold: 50,
+        isPercentage: true,
+      });
+    });
+
+    it('parses implicit > 0: keyword:flying', () => {
+      const result = parseCheckExpression('keyword:flying');
+      expect(result.error).toBeNull();
+      expect(result.expression).toEqual({
+        type: 'count',
+        cardFilter: 'keyword:flying',
+        op: '>',
+        threshold: 0,
+        isPercentage: false,
+      });
+    });
+
+    it('parses with >= operator: cmc>3 >= 20', () => {
+      const result = parseCheckExpression('cmc>3 >= 20');
+      expect(result.error).toBeNull();
+      expect(result.expression).toEqual({
+        type: 'count',
+        cardFilter: 'cmc>3',
+        op: '>=',
+        threshold: 20,
+        isPercentage: false,
+      });
+    });
+
+    it('parses decimal threshold: type:creature > 33.3%', () => {
+      const result = parseCheckExpression('type:creature > 33.3%');
+      expect(result.error).toBeNull();
+      expect(result.expression).toEqual({
+        type: 'count',
+        cardFilter: 'type:creature',
+        op: '>',
+        threshold: 33.3,
+        isPercentage: true,
+      });
+    });
+  });
+
+  describe('relative checks', () => {
+    it('parses relative: t:instant >= t:sorcery', () => {
+      const result = parseCheckExpression('t:instant >= t:sorcery');
+      expect(result.error).toBeNull();
+      expect(result.expression).toEqual({
+        type: 'relative',
+        lhsFilter: 't:instant',
+        op: '>=',
+        rhsFilter: 't:sorcery',
+      });
+    });
+
+    it('parses relative with complex filters: c:u type:creature > c:r type:creature', () => {
+      const result = parseCheckExpression('c:u type:creature > c:r type:creature');
+      expect(result.error).toBeNull();
+      expect(result.expression).toEqual({
+        type: 'relative',
+        lhsFilter: 'c:u type:creature',
+        op: '>',
+        rhsFilter: 'c:r type:creature',
+      });
+    });
+  });
+
+  describe('aggregate checks', () => {
+    it('parses unscoped aggregate: avg(cmc) < 3.5', () => {
+      const result = parseCheckExpression('avg(cmc) < 3.5');
+      expect(result.error).toBeNull();
+      expect(result.expression).toEqual({
+        type: 'aggregate',
+        func: 'avg',
+        field: 'cmc',
+        cardFilter: null,
+        op: '<',
+        threshold: 3.5,
+      });
+    });
+
+    it('parses scoped aggregate: avg(cmc, type:creature) < 3', () => {
+      const result = parseCheckExpression('avg(cmc, type:creature) < 3');
+      expect(result.error).toBeNull();
+      expect(result.expression).toEqual({
+        type: 'aggregate',
+        func: 'avg',
+        field: 'cmc',
+        cardFilter: 'type:creature',
+        op: '<',
+        threshold: 3,
+      });
+    });
+
+    it('parses max aggregate: max(cmc) <= 7', () => {
+      const result = parseCheckExpression('max(cmc) <= 7');
+      expect(result.error).toBeNull();
+      expect(result.expression).toEqual({
+        type: 'aggregate',
+        func: 'max',
+        field: 'cmc',
+        cardFilter: null,
+        op: '<=',
+        threshold: 7,
+      });
+    });
+
+    it('parses median aggregate: median(words) > 10', () => {
+      const result = parseCheckExpression('median(words) > 10');
+      expect(result.error).toBeNull();
+      expect(result.expression).toEqual({
+        type: 'aggregate',
+        func: 'median',
+        field: 'words',
+        cardFilter: null,
+        op: '>',
+        threshold: 10,
+      });
+    });
+  });
+
+  describe('error cases', () => {
+    it('returns error for empty input', () => {
+      const result = parseCheckExpression('');
+      expect(result.expression).toBeNull();
+      expect(result.error).not.toBeNull();
+    });
+
+    it('returns error for aggregate with no comparison', () => {
+      const result = parseCheckExpression('avg(cmc)');
+      expect(result.expression).toBeNull();
+      expect(result.error).toContain('comparison');
+    });
+
+    it('returns error for invalid aggregate field', () => {
+      const result = parseCheckExpression('avg(invalid) > 5');
+      expect(result.expression).toBeNull();
+      expect(result.error).not.toBeNull();
+    });
+
+    it('returns error for invalid aggregate function', () => {
+      const result = parseCheckExpression('foo(cmc) > 5');
+      expect(result.expression).toBeNull();
+      expect(result.error).not.toBeNull();
+    });
+  });
+});

--- a/src/util/CheckExpressionParser.ts
+++ b/src/util/CheckExpressionParser.ts
@@ -7,6 +7,7 @@ import type {
   AggregateFunction,
   AggregateField
 } from '../types/checks';
+import { parseQuery } from './CardFilterParser';
 
 const COMPARISON_OPS = ['>=', '<=', '!=', '>', '<', '='] as const;
 const AGGREGATE_FUNCTIONS: AggregateFunction[] = ['avg', 'sum', 'min', 'max', 'median'];
@@ -15,6 +16,11 @@ const AGGREGATE_FIELDS: AggregateField[] = ['cmc', 'words', 'power', 'toughness'
 interface ParseCheckResult {
   expression: CheckExpression | null;
   error: string | null;
+}
+
+function validateCardFilter(filter: string): string | null {
+  const { error } = parseQuery(filter);
+  return error;
 }
 
 /**
@@ -112,6 +118,10 @@ export function parseCheckExpression(input: string): ParseCheckResult {
 
   // No top-level operator → implicit > 0 count check
   if (!topOp) {
+    const filterError = validateCardFilter(trimmed);
+    if (filterError) {
+      return { expression: null, error: filterError };
+    }
     return {
       expression: {
         type: 'count',
@@ -141,6 +151,12 @@ export function parseCheckExpression(input: string): ParseCheckResult {
     }
     if (threshold.isPercentage) {
       return { expression: null, error: 'Percentage thresholds are not supported for aggregate functions' };
+    }
+    if (agg.cardFilter) {
+      const filterError = validateCardFilter(agg.cardFilter);
+      if (filterError) {
+        return { expression: null, error: filterError };
+      }
     }
     return {
       expression: {
@@ -172,6 +188,10 @@ export function parseCheckExpression(input: string): ParseCheckResult {
   // Try threshold (count check) vs card filter (relative check)
   const threshold = parseThreshold(rhs);
   if (threshold) {
+    const filterError = validateCardFilter(lhs);
+    if (filterError) {
+      return { expression: null, error: filterError };
+    }
     return {
       expression: {
         type: 'count',
@@ -185,6 +205,14 @@ export function parseCheckExpression(input: string): ParseCheckResult {
   }
 
   // RHS is not numeric → relative check
+  const lhsFilterError = validateCardFilter(lhs);
+  if (lhsFilterError) {
+    return { expression: null, error: lhsFilterError };
+  }
+  const rhsFilterError = validateCardFilter(rhs);
+  if (rhsFilterError) {
+    return { expression: null, error: rhsFilterError };
+  }
   return {
     expression: {
       type: 'relative',

--- a/src/util/CheckExpressionParser.ts
+++ b/src/util/CheckExpressionParser.ts
@@ -1,0 +1,197 @@
+import type {
+  CheckExpression,
+  CountCheck,
+  RelativeCheck,
+  AggregateCheck,
+  ComparisonOp,
+  AggregateFunction,
+  AggregateField
+} from '../types/checks';
+
+const COMPARISON_OPS = ['>=', '<=', '!=', '>', '<', '='] as const;
+const AGGREGATE_FUNCTIONS: AggregateFunction[] = ['avg', 'sum', 'min', 'max', 'median'];
+const AGGREGATE_FIELDS: AggregateField[] = ['cmc', 'words', 'power', 'toughness', 'elo', 'usd', 'tix', 'year'];
+
+interface ParseCheckResult {
+  expression: CheckExpression | null;
+  error: string | null;
+}
+
+/**
+ * Find the top-level comparison operator in the expression.
+ * Top-level operators are surrounded by whitespace.
+ * Scans right-to-left to find the last such operator (handles relative comparisons).
+ */
+function findTopLevelOp(input: string): { op: ComparisonOp; index: number } | null {
+  // Scan right-to-left for whitespace-surrounded comparison operators
+  for (let i = input.length - 1; i >= 0; i--) {
+    for (const op of COMPARISON_OPS) {
+      if (i - op.length < 0) continue;
+      const start = i - op.length + 1;
+      const slice = input.slice(start, i + 1);
+      if (slice !== op) continue;
+
+      // Check for surrounding whitespace
+      const before = start - 1;
+      const after = i + 1;
+      if (before < 0 || after >= input.length) continue;
+      if (input[before] !== ' ' || input[after] !== ' ') continue;
+
+      // Skip if inside parentheses
+      let depth = 0;
+      for (let j = 0; j < start; j++) {
+        if (input[j] === '(') depth++;
+        if (input[j] === ')') depth--;
+      }
+      if (depth > 0) continue;
+
+      return { op: op as ComparisonOp, index: start };
+    }
+  }
+  return null;
+}
+
+/**
+ * Check if a string looks like a numeric threshold (with optional %).
+ */
+function parseThreshold(s: string): { value: number; isPercentage: boolean } | null {
+  const trimmed = s.trim();
+  const isPercentage = trimmed.endsWith('%');
+  const numStr = isPercentage ? trimmed.slice(0, -1) : trimmed;
+  const value = parseFloat(numStr);
+  if (isNaN(value)) return null;
+  return { value, isPercentage };
+}
+
+/**
+ * Try to parse as an aggregate expression.
+ * Pattern: func(field) or func(field, cardFilter)
+ */
+function parseAggregate(lhs: string): { func: AggregateFunction; field: AggregateField; cardFilter: string | null } | null {
+  const match = lhs.match(/^(avg|sum|min|max|median)\((.+)\)$/);
+  if (!match) return null;
+
+  const func = match[1] as AggregateFunction;
+  const inner = match[2];
+
+  // Split on first comma for field vs card filter
+  const commaIndex = inner.indexOf(',');
+  let fieldStr: string;
+  let cardFilter: string | null = null;
+
+  if (commaIndex === -1) {
+    fieldStr = inner.trim();
+  } else {
+    fieldStr = inner.slice(0, commaIndex).trim();
+    cardFilter = inner.slice(commaIndex + 1).trim();
+  }
+
+  if (!AGGREGATE_FIELDS.includes(fieldStr as AggregateField)) {
+    return null;
+  }
+
+  return { func, field: fieldStr as AggregateField, cardFilter };
+}
+
+export function parseCheckExpression(input: string): ParseCheckResult {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return { expression: null, error: 'Expression cannot be empty' };
+  }
+
+  // Check if LHS starts with an aggregate function
+  const aggFuncMatch = trimmed.match(/^(avg|sum|min|max|median)\(/);
+
+  // Find top-level comparison operator
+  const topOp = findTopLevelOp(trimmed);
+
+  // Aggregate without comparison is an error
+  if (aggFuncMatch && !topOp) {
+    return { expression: null, error: 'Aggregate expressions require a comparison operator (e.g., avg(cmc) < 3.5)' };
+  }
+
+  // No top-level operator → implicit > 0 count check
+  if (!topOp) {
+    return {
+      expression: {
+        type: 'count',
+        cardFilter: trimmed,
+        op: '>',
+        threshold: 0,
+        isPercentage: false,
+      } satisfies CountCheck,
+      error: null,
+    };
+  }
+
+  const lhs = trimmed.slice(0, topOp.index).trimEnd();
+  const rhs = trimmed.slice(topOp.index + topOp.op.length).trimStart();
+  const op = topOp.op;
+
+  if (!lhs || !rhs) {
+    return { expression: null, error: 'Missing left-hand or right-hand side of comparison' };
+  }
+
+  // Try aggregate
+  const agg = parseAggregate(lhs);
+  if (agg) {
+    const threshold = parseThreshold(rhs);
+    if (!threshold) {
+      return { expression: null, error: `Invalid threshold: "${rhs}". Expected a number.` };
+    }
+    if (threshold.isPercentage) {
+      return { expression: null, error: 'Percentage thresholds are not supported for aggregate functions' };
+    }
+    return {
+      expression: {
+        type: 'aggregate',
+        func: agg.func,
+        field: agg.field,
+        cardFilter: agg.cardFilter,
+        op,
+        threshold: threshold.value,
+      } satisfies AggregateCheck,
+      error: null,
+    };
+  }
+
+  // Check if aggregate function name but failed to parse (bad field)
+  if (aggFuncMatch) {
+    const funcName = aggFuncMatch[1];
+    if (AGGREGATE_FUNCTIONS.includes(funcName as AggregateFunction)) {
+      return { expression: null, error: `Invalid aggregate field in ${funcName}(). Valid fields: ${AGGREGATE_FIELDS.join(', ')}` };
+    }
+  }
+
+  // Check if LHS looks like a function call with an invalid function name
+  const funcCallMatch = lhs.match(/^(\w+)\(.+\)$/);
+  if (funcCallMatch && !AGGREGATE_FUNCTIONS.includes(funcCallMatch[1] as AggregateFunction)) {
+    return { expression: null, error: `Unknown aggregate function "${funcCallMatch[1]}". Valid functions: ${AGGREGATE_FUNCTIONS.join(', ')}` };
+  }
+
+  // Try threshold (count check) vs card filter (relative check)
+  const threshold = parseThreshold(rhs);
+  if (threshold) {
+    return {
+      expression: {
+        type: 'count',
+        cardFilter: lhs,
+        op,
+        threshold: threshold.value,
+        isPercentage: threshold.isPercentage,
+      } satisfies CountCheck,
+      error: null,
+    };
+  }
+
+  // RHS is not numeric → relative check
+  return {
+    expression: {
+      type: 'relative',
+      lhsFilter: lhs,
+      op,
+      rhsFilter: rhs,
+    } satisfies RelativeCheck,
+    error: null,
+  };
+}

--- a/src/util/CubeFilterEvaluator.ts
+++ b/src/util/CubeFilterEvaluator.ts
@@ -7,6 +7,7 @@ import type { QueryNode } from './CardFilterParser';
 export interface CubeFilterContext {
     /** Cards for this cube (from loadedCubes[id].cards) */
     cards: Array<{ name: string; colors?: string[]; [key: string]: any }>;
+    checksPassCount?: number;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -73,6 +74,10 @@ const CUBE_KEYWORD_ALIASES: Record<string, string> = {
     multicolor: 'multicolor',
     multi: 'multicolor',
     m: 'multicolor',
+    // Checks
+    checks: 'checks',
+    check: 'checks',
+    passed: 'checks',
     // Playability
     game: 'game',
     in: 'game',
@@ -127,6 +132,7 @@ const CUBE_ORDER_ALIASES: Record<string, { prop: string; defaultOrder: 'ascendin
     tix: { prop: 'stats.totalMinPriceTix', defaultOrder: 'descending' },
     words: { prop: 'stats.averageWordCount', defaultOrder: 'ascending' },
     removal: { prop: 'stats.cardCounts.removal', defaultOrder: 'descending' },
+    checks: { prop: 'checksPassCount', defaultOrder: 'descending' },
 };
 
 const CUBE_DIRECTION_ALIASES: Record<string, 'ascending' | 'descending'> = {
@@ -342,6 +348,10 @@ function evaluateCondition(keyword: string, op: string, value: string | number, 
             // : operator = substring match
             return ctx.cards.some(card => card.name?.toLowerCase().includes(cardName.toLowerCase()));
         }
+
+        // ── Checks ──
+        case 'checks':
+            return compareValues(ctx.checksPassCount ?? 0, op, Number(value));
 
         // ── Sort directives (handled externally; never filter rows) ──
         case 'order':

--- a/src/util/useHashRouter.ts
+++ b/src/util/useHashRouter.ts
@@ -13,7 +13,7 @@ export interface HashRouterState {
     allCards: boolean;
 }
 
-const VALID_TABS = ['overview', 'infographic', 'statistics', 'compare', 'cards', 'about'];
+const VALID_TABS = ['overview', 'infographic', 'statistics', 'compare', 'cards', 'checks', 'about'];
 
 export function parseHash(hash: string): HashRouterState {
     // Expected: #/{tab}?{params} or empty


### PR DESCRIPTION
I'll consider this v1. I'm not totally sure on the whole Collection > Checks hierarchy, and from there whether only one collection should be active at a time. The CubeDetail could just show them all and the main Overview table could just have entries for each.
Constraining how many checks are evaluated at the same time probably helps...

Another thing that is becoming really apparent is the need for column reordering.