### PR TITLE
feat: add filtering logic to preloads

### DIFF
--- a/preload-cube-data.ts
+++ b/preload-cube-data.ts
@@ -36,6 +36,8 @@ function isStale(filePath: string, thresholdMs: number): boolean {
 }
 
 async function loadManifests(): Promise<Manifest[]> {
+    // Only manifest modules live at the top level of MANIFESTS_DIR.
+    // Shared types, helpers, and tests are excluded from auto-loading.
     const files = fs.readdirSync(MANIFESTS_DIR).filter(f =>
         f.endsWith('.ts') && f !== 'types.ts' && f !== 'filters.ts' && !f.endsWith('.test.ts'),
     );
@@ -291,8 +293,10 @@ async function phasePrune(manifests: Manifest[]) {
     }
 
     // Prune generated/cubes/ — keep only IDs present in presets.json.
+    // Skip if presets.json is missing (e.g. --fetch-only before any assemble)
+    // so we never wipe generated/ based on an empty ID set.
     let generatedRemoved = 0;
-    if (fs.existsSync(GENERATED_CUBES_DIR)) {
+    if (fs.existsSync(presetsPath) && fs.existsSync(GENERATED_CUBES_DIR)) {
         for (const file of fs.readdirSync(GENERATED_CUBES_DIR)) {
             const id = file.replace('.json', '');
             if (!generatedIds.has(id)) {

--- a/preload-cube-data.ts
+++ b/preload-cube-data.ts
@@ -4,7 +4,8 @@ import { remapCube, computeSimilarityMatrix } from './src/util/CubeFunctions';
 import { getCubeData, fetchTopCubeIds } from './src/util/CubeCobra';
 import type { Cube } from './src/types';
 import type { PresetCollection } from './src/types/presets';
-import type { Manifest } from './preloads/manifests/types';
+import type { CubePredicate, Manifest } from './preloads/manifests/types';
+import { parseDuration } from './preloads/manifests/filters';
 
 // --- Configuration ---
 
@@ -27,19 +28,6 @@ const assembleOnly = args.includes('--assemble-only');
 
 // --- Helpers ---
 
-function parseThreshold(threshold: string): number {
-    const match = threshold.match(/^(\d+)([dhm])$/);
-    if (!match) throw new Error(`Invalid staleThreshold format: "${threshold}"`);
-    const value = parseInt(match[1], 10);
-    const unit = match[2];
-    switch (unit) {
-        case 'd': return value * 24 * 60 * 60 * 1000;
-        case 'h': return value * 60 * 60 * 1000;
-        case 'm': return value * 60 * 1000;
-        default: throw new Error(`Unknown unit: ${unit}`);
-    }
-}
-
 function isStale(filePath: string, thresholdMs: number): boolean {
     if (!fs.existsSync(filePath)) return true;
     const stats = fs.statSync(filePath);
@@ -48,7 +36,9 @@ function isStale(filePath: string, thresholdMs: number): boolean {
 }
 
 async function loadManifests(): Promise<Manifest[]> {
-    const files = fs.readdirSync(MANIFESTS_DIR).filter(f => f.endsWith('.ts') && f !== 'types.ts');
+    const files = fs.readdirSync(MANIFESTS_DIR).filter(f =>
+        f.endsWith('.ts') && f !== 'types.ts' && f !== 'filters.ts' && !f.endsWith('.test.ts'),
+    );
     const manifests: Manifest[] = [];
     for (const f of files) {
         const mod = await import(path.resolve(MANIFESTS_DIR, f));
@@ -128,7 +118,7 @@ async function phaseFetch(manifests: Manifest[]) {
                     continue;
                 }
 
-                const thresholdMs = parseThreshold(manifest.fetch.staleThreshold);
+                const thresholdMs = parseDuration(manifest.fetch.staleThreshold);
 
                 // CI without REFRESH_PRELOADS: skip all fetches
                 if (isCI && !refresh) {
@@ -177,6 +167,11 @@ async function phaseFetch(manifests: Manifest[]) {
 
 // --- Phase 2: Assemble ---
 
+function normalizeIncludes(include: Manifest['include']): CubePredicate[] {
+    if (!include) return [];
+    return Array.isArray(include) ? include : [include];
+}
+
 async function phaseAssemble(manifests: Manifest[]) {
     console.log('\n=== Phase 2: Assemble ===\n');
 
@@ -208,6 +203,12 @@ async function phaseAssemble(manifests: Manifest[]) {
             try {
                 const raw = JSON.parse(fs.readFileSync(cachePath, 'utf-8'));
                 const cube = remapCube(raw, false, fetchedAt);
+
+                const predicates = normalizeIncludes(manifest.include);
+                if (predicates.length && !predicates.every(p => p(cube))) {
+                    console.log(`[${cubeId}] Filtered out by include predicates.`);
+                    continue;
+                }
 
                 // Use the canonical cube.id as the key
                 remappedCubes[cube.id] = cube;

--- a/preload-cube-data.ts
+++ b/preload-cube-data.ts
@@ -261,52 +261,48 @@ async function phaseAssemble(manifests: Manifest[]) {
 async function phasePrune(manifests: Manifest[]) {
     console.log('\n=== Phase 3: Prune ===\n');
 
-    // Collect all cube IDs referenced by any manifest (including dynamic sources)
-    const referencedIds = new Set<string>();
+    // IDs referenced by any manifest (raw list; filter-agnostic).
+    const manifestIds = new Set<string>();
     for (const manifest of manifests) {
         const cubeIds = await resolveManifestCubes(manifest);
-        for (const id of cubeIds) {
-            referencedIds.add(id);
-        }
+        for (const id of cubeIds) manifestIds.add(id);
     }
 
-    // Also include canonical IDs from generated cubes (remapCube may change IDs)
-    // Read the presets.json to get the canonical IDs that were actually written
+    // Canonical IDs actually written to generated/ this run (post-filter).
+    const generatedIds = new Set<string>();
     const presetsPath = path.join(GENERATED_DIR, 'presets.json');
     if (fs.existsSync(presetsPath)) {
         const presets: PresetCollection[] = JSON.parse(fs.readFileSync(presetsPath, 'utf-8'));
         for (const preset of presets) {
-            for (const id of Object.keys(preset.cubes)) {
-                referencedIds.add(id);
-            }
+            for (const id of Object.keys(preset.cubes)) generatedIds.add(id);
         }
     }
 
-    // Prune cache/cubes/
+    // Prune cache/cubes/ — keep anything referenced by a manifest.
     let cacheRemoved = 0;
     if (fs.existsSync(CACHE_CUBES_DIR)) {
         for (const file of fs.readdirSync(CACHE_CUBES_DIR)) {
             const id = file.replace('.json', '');
-            if (!referencedIds.has(id)) {
+            if (!manifestIds.has(id)) {
                 fs.unlinkSync(path.join(CACHE_CUBES_DIR, file));
                 cacheRemoved++;
             }
         }
     }
 
-    // Prune generated/cubes/
+    // Prune generated/cubes/ — keep only IDs present in presets.json.
     let generatedRemoved = 0;
     if (fs.existsSync(GENERATED_CUBES_DIR)) {
         for (const file of fs.readdirSync(GENERATED_CUBES_DIR)) {
             const id = file.replace('.json', '');
-            if (!referencedIds.has(id)) {
+            if (!generatedIds.has(id)) {
                 fs.unlinkSync(path.join(GENERATED_CUBES_DIR, file));
                 generatedRemoved++;
             }
         }
     }
 
-    // Prune generated/similarities/ (remove matrices for manifests that no longer exist)
+    // Prune generated/similarities/ — keep only current manifest names.
     let simRemoved = 0;
     const manifestNames = new Set(manifests.map(m => m.name));
     if (fs.existsSync(GENERATED_SIMILARITIES_DIR)) {

--- a/preloads/manifests/filters.test.ts
+++ b/preloads/manifests/filters.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { parseDuration, modifiedSince } from './filters';
+import type { Cube } from '../../src/types';
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+function cubeWith(lastModified: Cube['lastModified']): Cube {
+    return {
+        id: 'x',
+        name: 'x',
+        owner: 'x',
+        cards: [],
+        lastModified,
+    } as Cube;
+}
+
+describe('parseDuration', () => {
+    it('parses minutes', () => {
+        expect(parseDuration('30m')).toBe(30 * 60 * 1000);
+    });
+    it('parses hours', () => {
+        expect(parseDuration('4h')).toBe(4 * HOUR_MS);
+    });
+    it('parses days', () => {
+        expect(parseDuration('1d')).toBe(DAY_MS);
+    });
+    it('parses months as 30 days', () => {
+        expect(parseDuration('6mo')).toBe(6 * 30 * DAY_MS);
+    });
+    it('parses years as 365 days', () => {
+        expect(parseDuration('1y')).toBe(365 * DAY_MS);
+    });
+    it('throws on malformed input', () => {
+        expect(() => parseDuration('6months')).toThrow();
+        expect(() => parseDuration('')).toThrow();
+        expect(() => parseDuration('abc')).toThrow();
+        expect(() => parseDuration('6')).toThrow();
+    });
+});
+
+describe('modifiedSince', () => {
+    const NOW = Date.parse('2026-08-06T00:00:00Z');
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(NOW);
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('keeps cubes modified within the window (string date)', () => {
+        const cube = cubeWith(new Date(NOW - 30 * DAY_MS).toISOString());
+        expect(modifiedSince('6mo')(cube)).toBe(true);
+    });
+
+    it('keeps cubes modified within the window (numeric epoch ms)', () => {
+        const cube = cubeWith(NOW - 30 * DAY_MS);
+        expect(modifiedSince('6mo')(cube)).toBe(true);
+    });
+
+    it('drops cubes modified outside the window', () => {
+        const cube = cubeWith(new Date(NOW - 200 * DAY_MS).toISOString());
+        expect(modifiedSince('6mo')(cube)).toBe(false);
+    });
+
+    it('drops cubes with missing lastModified', () => {
+        expect(modifiedSince('6mo')(cubeWith(undefined))).toBe(false);
+    });
+
+    it('drops cubes with unparseable lastModified string', () => {
+        expect(modifiedSince('6mo')(cubeWith('not-a-date'))).toBe(false);
+    });
+});

--- a/preloads/manifests/filters.ts
+++ b/preloads/manifests/filters.ts
@@ -1,0 +1,33 @@
+import type { Cube } from '../../src/types';
+import type { CubePredicate } from './types';
+
+const UNIT_MS: Record<string, number> = {
+    m: 60 * 1000,
+    h: 60 * 60 * 1000,
+    d: 24 * 60 * 60 * 1000,
+    mo: 30 * 24 * 60 * 60 * 1000,
+    y: 365 * 24 * 60 * 60 * 1000,
+};
+
+export function parseDuration(input: string): number {
+    const match = /^(\d+)(mo|m|h|d|y)$/.exec(input);
+    if (!match) throw new Error(`Invalid duration: "${input}"`);
+    const value = Number.parseInt(match[1], 10);
+    return value * UNIT_MS[match[2]];
+}
+
+function parseLastModified(value: Cube['lastModified']): number | null {
+    if (value == null) return null;
+    if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? null : parsed;
+}
+
+export function modifiedSince(duration: string): CubePredicate {
+    const windowMs = parseDuration(duration);
+    return (cube) => {
+        const ts = parseLastModified(cube.lastModified);
+        if (ts == null) return false;
+        return (Date.now() - ts) <= windowMs;
+    };
+}

--- a/preloads/manifests/peasant.ts
+++ b/preloads/manifests/peasant.ts
@@ -114,6 +114,7 @@ const manifest: Manifest = {
         '637b9e8cd7d17f14ab27f4c9', // RoroLeZozo - Synergy Peasant Cube
         '5dbcbd2a44e9cb7a6c8097cf', // ahhabee - C/U be
         '5e539a45e74a617cdd462f32', // gsethi - Gsethi 360 Peasant Cube
+        '9bd7c4dc-408d-4ebb-b08a-039528a4a50e', // CloudedBirb - Peasant Vintage PowerMax!
     ],
 };
 

--- a/preloads/manifests/peasant.ts
+++ b/preloads/manifests/peasant.ts
@@ -1,3 +1,4 @@
+import { modifiedSince } from './filters';
 import type { Manifest } from './types';
 
 const manifest: Manifest = {
@@ -8,6 +9,7 @@ const manifest: Manifest = {
         { label: 'Discord', url: 'https://discord.gg/D7EB3PSJtN', type: 'discord' },
     ],
     fetch: { staleThreshold: '1d', shardCount: 4 },
+    include: [modifiedSince('6mo')],
     cubes: [
         '5d5f69612af66a30f9bb9b10', // Crunchwrap Supreme
         '61f51c3df1d9250f21664d1a', // AlfonsoGallegoF - 450 Peasant+

--- a/preloads/manifests/types.ts
+++ b/preloads/manifests/types.ts
@@ -1,3 +1,7 @@
+import type { Cube } from '../../src/types';
+
+export type CubePredicate = (cube: Cube) => boolean;
+
 export interface ManifestFetch {
     staleThreshold: string;
     shardCount: number;

--- a/preloads/manifests/types.ts
+++ b/preloads/manifests/types.ts
@@ -16,4 +16,5 @@ export interface Manifest {
     links?: Array<{ label: string; url: string; type?: string }>;
     fetch: ManifestFetch | null;
     cubes: string[];
+    include?: CubePredicate | CubePredicate[];
 }


### PR DESCRIPTION
This is only being applied to the Peasant list, but the idea is to run a set of checks against the cubes and include/exclude them based on that.

For peasant this means a check on whether it was updated in the last 6 months.