### PR TITLE
fix: restore preset-load streaming; chunked processing for smaller flush count

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ npm run cards:update
 
 ## Load-time Profiling
 
-Set `VITE_LOAD_PROFILE=1` to log per-phase timings during preset loads. When unset, the profiler compiles out entirely.
+Enable via either mechanism to log per-phase timings during preset loads.
+
+**Build-time (dev):**
 
 ```sh
 # One-off run
@@ -35,6 +37,18 @@ VITE_LOAD_PROFILE=1 npm run serve
 
 # Or add to .env.local (gitignored)
 echo 'VITE_LOAD_PROFILE=1' >> .env.local
+```
+
+**Runtime (any build, including production):** set a localStorage flag and reload.
+
+```js
+// In the browser DevTools console
+localStorage.setItem('loadProfile', '1');
+location.reload();
+
+// To disable:
+localStorage.removeItem('loadProfile');
+location.reload();
 ```
 
 Each `loadCollection` emits a `LOAD PROFILE <preset name> { ... }` line with buckets for `enrichCube`, `updateSim`, `warmSim`, `getCached`, `mergeMatrix`, `similarityLoad`, `checksFires`, `checksEvals`, and `cubePromisesTotal`.

--- a/src/App.vue
+++ b/src/App.vue
@@ -808,6 +808,11 @@ const loadCollection = async (presetName: string) => {
         bump(profile, 'getCached', performance.now() - bulkStart);
 
         const cubePromises = cubeEntries.map(async ([id, meta]) => {
+            // Yield so each cube's reactive mutation lands in its own macrotask.
+            // Without this the tier-1 (cache) branch runs entirely synchronously
+            // — all 71 mutations batch into a single Vue flush at the end and the
+            // progress bar sits at 0/N until the last cube.
+            await new Promise(resolve => setTimeout(resolve, 0));
             try {
                 const cached = bulkCache.get(id) ?? null;
                 const cubeKey = `../preloads/generated/cubes/${id}.json`;

--- a/src/App.vue
+++ b/src/App.vue
@@ -807,12 +807,15 @@ const loadCollection = async (presetName: string) => {
         const bulkCache = await getCachedCubesBulk(cubeEntries.map(([id]) => id));
         bump(profile, 'getCached', performance.now() - bulkStart);
 
-        const cubePromises = cubeEntries.map(async ([id, meta]) => {
-            // Yield so each cube's reactive mutation lands in its own macrotask.
-            // Without this the tier-1 (cache) branch runs entirely synchronously
-            // — all 71 mutations batch into a single Vue flush at the end and the
-            // progress bar sits at 0/N until the last cube.
-            await new Promise(resolve => setTimeout(resolve, 0));
+        // Process cubes in small chunks. All mutations inside a chunk batch into
+        // a single Vue reactive flush; the setTimeout(0) between chunks lets Vue
+        // flush and the browser paint. Chunk size 10 balances two ~1 ms tension
+        // points: bigger chunks reduce total time (fewer flushes to recompute
+        // downstream computeds) at the cost of coarser progress visibility. On a
+        // 71-cube preset that's 8 visible progress ticks vs. 14 at chunk 5, for
+        // a ~600 ms wall-time saving in dev (likely larger in prod).
+        const CHUNK_SIZE = 10;
+        const processCube = async ([id, meta]: [string, import('./types').PresetCubeEntry]) => {
             try {
                 const cached = bulkCache.get(id) ?? null;
                 const cubeKey = `../preloads/generated/cubes/${id}.json`;
@@ -857,7 +860,16 @@ const loadCollection = async (presetName: string) => {
             } finally {
                 loadingProgress.loaded++;
             }
-        });
+        };
+
+        const chunkedCubePromise = (async () => {
+            for (let i = 0; i < cubeEntries.length; i += CHUNK_SIZE) {
+                const chunk = cubeEntries.slice(i, i + CHUNK_SIZE);
+                await Promise.all(chunk.map(processCube));
+                // Yield so Vue flushes and the browser paints between chunks.
+                await new Promise(resolve => setTimeout(resolve, 0));
+            }
+        })();
 
         const similarityLandingPromise = similarityPromise.then(sim => {
             if (sim) {
@@ -873,7 +885,7 @@ const loadCollection = async (presetName: string) => {
             bump(profile, 'similarityLoad', performance.now() - profileStart);
         });
 
-        await Promise.all([...cubePromises, similarityLandingPromise]);
+        await Promise.all([chunkedCubePromise, similarityLandingPromise]);
         bump(profile, 'cubePromisesTotal', performance.now() - profileStart);
     } finally {
         loadingProgress.active = false;

--- a/src/util/LoadProfile.ts
+++ b/src/util/LoadProfile.ts
@@ -1,15 +1,28 @@
 /**
- * Gated profiler for the preset-load hot path. Enabled by setting the Vite env
- * variable VITE_LOAD_PROFILE to any truthy value. When disabled, the flag is a
- * compile-time false and Vite tree-shakes the timing calls out of the bundle.
+ * Gated profiler for the preset-load hot path. Enabled by either:
+ *   - Build time: set the Vite env variable VITE_LOAD_PROFILE=1 (or add it to
+ *     .env.local, or run `VITE_LOAD_PROFILE=1 npm run dev`). Tree-shakes the
+ *     timing calls out of the bundle when unset at build time.
+ *   - Runtime: `localStorage.setItem('loadProfile', '1'); location.reload()`.
+ *     Works in any build — including production — without a redeploy. Clear
+ *     with `localStorage.removeItem('loadProfile'); location.reload()`.
  *
- * Usage:
- *   VITE_LOAD_PROFILE=1 npm run dev
- *
- * or add `VITE_LOAD_PROFILE=1` to `.env.local`.
+ * When both are unset, `timed`/`bump` short-circuit on a single boolean
+ * branch — no measurable overhead.
  */
 
-export const loadProfileEnabled: boolean = !!import.meta.env.VITE_LOAD_PROFILE;
+const LOCAL_STORAGE_KEY = 'loadProfile';
+
+function readInitialFlag(): boolean {
+    if (import.meta.env.VITE_LOAD_PROFILE) return true;
+    try {
+        return globalThis.localStorage?.getItem(LOCAL_STORAGE_KEY) === '1';
+    } catch {
+        return false;
+    }
+}
+
+export const loadProfileEnabled: boolean = readInitialFlag();
 
 export interface LoadProfile {
     enrichCube: number;


### PR DESCRIPTION
## Summary

Fixes a streaming regression introduced by the bulk IDB read in #561: the tier-1 (cache) branch no longer had any `await` inside its async body, so all 71 reactive mutations batched into a single Vue flush at the end and the progress bar sat at `0 / 71` until the last cube landed. On the CubeCon 2026 production preset this manifested as an **11.8 s** wall time with no visible progress.

Also enables enabling the load profiler from production via `localStorage`, so we can capture LOAD PROFILE traces from real users without a rebuild.

## Findings

`.map(async ...)` fires each async function eagerly; each body runs until the first `await`. In the tier-1 path there was none, so 71 bodies ran synchronously in one call stack. Vue batches all mutations in a single microtask into one flush. That flush covered every downstream computed and DOM patch at once — expensive in real browsers, and invisible until it finished.

Before #561 the `await getCachedCube(id)` inside each promise had provided an accidental yield between cubes. The bulk IDB refactor hoisted that `await` out, removing the yield without noticing that it was load-bearing for UX.

## Commits

1. **`fix: yield between cubes so preset load streams incrementally`** — one-line `await new Promise(r => setTimeout(r, 0))` at the top of each per-cube async function. Restored the visible progress bar. Dev: 1285 → 1926 ms; streams `0 → 6 → 15 → 21 → 30 → 39 → 45 → 51 → 57 → 60 → 66 → done`.
2. **`perf: chunked parallel processing for preset cube loads`** — replaces the per-cube yield with a chunked loop that processes `CHUNK_SIZE = 10` cubes per macrotask before yielding. All mutations in a chunk batch into one flush; between chunks Vue flushes and the browser paints. Chose 10 after a sweep (5 → 1920 ms, 10 → 1320 ms, 15 → 1290 ms, 25 → 1250 ms) — captures ~85% of the achievable saving while keeping 8 visible progress steps for a 71-cube preset. Dev: 1926 → 1320 ms; streams `0 → 10 → 20 → 30 → 40 → 50 → 60 → 70 → done` over ~1.8 s.
3. **`feat: allow enabling load profile via localStorage flag`** — the profiler now activates on either `VITE_LOAD_PROFILE` at build time OR `localStorage.setItem('loadProfile', '1')` at runtime. Lets us capture production profile traces without redeploying.

## Verification

- 235 / 235 tests pass.
- `npm run build` clean.
- Progress polling on the dev server confirmed streaming in 8 visible chunks.
- localStorage toggle verified: `removeItem` → no profile line; `setItem('1')` + reload → `LOAD PROFILE CubeCon 2026 { ... }` emitted.

## Production impact

Dev's chunk-size sweep suggests a per-flush fixed cost of ~120 ms. In production that cost is likely several times larger (real reactive graph, real DOM patching), so cutting from 71 flushes down to 8 should meaningfully shrink the 11.8 s baseline. Once merged, capture the actual number from production by:

```js
localStorage.setItem('loadProfile', '1'); location.reload();
```

and read the `LOAD PROFILE` line from the DevTools console.
