### PR TITLE
perf: eliminate wasted similarity work + preload the sim chunk + clean URL during load

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -830,7 +830,6 @@ const loadCollection = async (presetName: string) => {
                     case 'cache': {
                         loadedCubes.value[id] = timed(profile, 'enrichCube', () => { bump(profile, 'enrichCount'); return enrichCube(cached!.data); });
                         timed(profile, 'warmSim', () => { bump(profile, 'warmSimCount'); warmSimilarityCacheForCube(id, loadedCubes.value, similarityMatrix.value); });
-                        timed(profile, 'updateSim', () => { bump(profile, 'updateSimCount'); updateSimilarityForCube(id, loadedCubes.value, similarityMatrix.value); });
                         if (source.refresh === 'preload') void backgroundRefreshFromPreload(id, meta);
                         else if (source.refresh === 'live') void backgroundRefreshCube(cached!.id);
                         return;
@@ -841,7 +840,6 @@ const loadCollection = async (presetName: string) => {
                         void setCachedCubeIfNewer(id, cube, cube.fetchedAt ?? meta.fetchedAt);
                         loadedCubes.value[id] = timed(profile, 'enrichCube', () => { bump(profile, 'enrichCount'); return enrichCube(cube); });
                         timed(profile, 'warmSim', () => { bump(profile, 'warmSimCount'); warmSimilarityCacheForCube(id, loadedCubes.value, similarityMatrix.value); });
-                        timed(profile, 'updateSim', () => { bump(profile, 'updateSimCount'); updateSimilarityForCube(id, loadedCubes.value, similarityMatrix.value); });
                         return;
                     }
                     case 'live': {
@@ -851,7 +849,6 @@ const loadCollection = async (presetName: string) => {
                         await setCachedCube(id, cube, fetchedAt);
                         loadedCubes.value[id] = timed(profile, 'enrichCube', () => { bump(profile, 'enrichCount'); return enrichCube(cube); });
                         timed(profile, 'warmSim', () => { bump(profile, 'warmSimCount'); warmSimilarityCacheForCube(id, loadedCubes.value, similarityMatrix.value); });
-                        timed(profile, 'updateSim', () => { bump(profile, 'updateSimCount'); updateSimilarityForCube(id, loadedCubes.value, similarityMatrix.value); });
                         return;
                     }
                 }
@@ -886,6 +883,18 @@ const loadCollection = async (presetName: string) => {
         });
 
         await Promise.all([chunkedCubePromise, similarityLandingPromise]);
+
+        // Sweep for cubes not covered by the preloaded similarity matrix.
+        // In the common case (preset loaded, similarity JSON present) every cube's
+        // row is already populated by mergeSimilarityMatrices and this is a no-op.
+        // Only fires for cubes added to a preset since the preload was generated,
+        // or when the similarity fetch failed entirely.
+        for (const id of Object.keys(loadedCubes.value)) {
+            if (!similarityMatrix.value[id]) {
+                timed(profile, 'updateSim', () => { bump(profile, 'updateSimCount'); updateSimilarityForCube(id, loadedCubes.value, similarityMatrix.value); });
+            }
+        }
+
         bump(profile, 'cubePromisesTotal', performance.now() - profileStart);
     } finally {
         loadingProgress.active = false;

--- a/src/App.vue
+++ b/src/App.vue
@@ -306,8 +306,14 @@ watch(
         overviewSortDirection,
         comparePair,
         showAllCards,
+        // Sync when loading finishes so the URL flips back to a clean ?preset=name.
+        // Also gate the effect so intermediate loading states don't leak "remove=<huge list>".
+        () => loadingProgress.active,
     ],
-    () => { debouncedSync(); },
+    () => {
+        if (loadingProgress.active) return;
+        debouncedSync();
+    },
 );
 
 onHashChange(async (newState) => {

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -20,8 +20,35 @@ function cardsPreloadPlugin() {
     };
 }
 
+// Emits an inline script that reads location.hash, extracts ?preset=name, and
+// injects a `<link rel="modulepreload">` for that preset's similarity chunk.
+// The browser starts fetching the ~500 KB similarity module during document
+// parse instead of waiting for onMounted → loadCollection to fire the dynamic
+// import. Dev is skipped.
+function similarityPreloadPlugin() {
+    return {
+        name: 'inject-similarity-preload',
+        transformIndexHtml(html, ctx) {
+            if (!ctx.bundle) return html;
+            const manifest = {};
+            for (const chunk of Object.values(ctx.bundle)) {
+                if (chunk.type !== 'chunk') continue;
+                const simModuleId = (chunk.moduleIds ?? []).find(id => id.includes('/preloads/generated/similarities/') && id.endsWith('.json'));
+                if (!simModuleId) continue;
+                const match = simModuleId.match(/\/similarities\/([^/]+)\.json$/);
+                if (!match) continue;
+                manifest[match[1]] = '/' + chunk.fileName;
+            }
+            if (Object.keys(manifest).length === 0) return html;
+
+            const script = `    <script>(function(){var m=location.hash.match(/[?&]preset=([^&]+)/);if(!m)return;var p=decodeURIComponent(m[1]);var u=(${JSON.stringify(manifest)})[p];if(!u)return;var l=document.createElement('link');l.rel='modulepreload';l.href=u;document.head.appendChild(l);})();<\/script>\n`;
+            return html.replace('</head>', `${script}</head>`);
+        },
+    };
+}
+
 export default defineConfig({
-    plugins: [vue(), cardsPreloadPlugin()],
+    plugins: [vue(), cardsPreloadPlugin(), similarityPreloadPlugin()],
     build: {
         sourcemap: true,
     },


### PR DESCRIPTION
## Summary

Three follow-ups to PR #562's production profiling that targeted the last remaining non-trivial buckets:

- `updateSim: 195 ms` → wasted work that gets overwritten by `mergeSimilarityMatrices` a few hundred ms later.
- `similarityLoad: 460 ms` → browser doesn't start fetching the similarity chunk until Vue boots and `loadCollection` fires the dynamic import.
- The URL bar filling with a comma-separated list of ~60 cube UUIDs during load — the URL sync watcher was serializing intermediate streaming state as "user removed these cubes".

## Commits

1. **`perf: skip wasted updateSimilarityForCube during streaming`** — remove the per-cube `updateSim` from the three tier branches; add a post-`Promise.all` sweep that only runs it for cubes not covered by the preloaded matrix (handles the sim-fetch-failed case and any delta cubes added since the preload was generated). Dev: 1320 → 1096-1260 ms; `updateSim` bucket goes 28 → 0 ms. Production prediction: -195 ms.
2. **`fix: suppress URL sync during preset loads`** — add `loadingProgress.active` as a watch dependency and gate the callback body. Watch still fires exactly once when the load completes, writing the clean `?preset=name` URL. Verified via URL polling: the hash stays `#/overview?preset=cubecon2026` end-to-end.
3. **`perf: preload the similarity JSON chunk for the URL-active preset`** — new Vite `similarityPreloadPlugin` that walks the bundle for chunks whose `moduleIds` include `/preloads/generated/similarities/*.json`, builds a `preset → chunkURL` manifest, and emits an inline `<script>` in `<head>` that parses `location.hash` and appends a `<link rel="modulepreload">` for that preset's chunk. Verified with `vite preview` + full-navigation goto: `cubecon2026-*.js` `startTime: 55 ms` (was ~460 ms in production profile).

## Verification

- 235 / 235 tests pass.
- `npm run build` clean; inspected `dist/index.html` — inline preload script present, manifest contains all 7 presets.
- Local production build served via `vite preview` confirms the modulepreload hint fires and the similarity chunk starts loading during document parse.

## Expected production impact

Applied to the last measured production profile (773 ms total, `updateSim 195 ms`, `similarityLoad 460 ms`):

| Change | Estimated saving |
|---|---|
| Skip wasted updateSim | -195 ms |
| URL sync suppression during load | -15-30 ms + UX fix |
| Similarity modulepreload | -200-300 ms |
| **Estimated post-PR total** | **~250-400 ms** |

Once merged, re-verify by loading the CubeCon 2026 preset in production with:

```js
localStorage.setItem('loadProfile', '1'); location.reload();
```

and comparing the `LOAD PROFILE` line against the pre-PR baseline in #562.
