### PR TITLE
Skip cards-minimized preload on return visits

### DIFF
--- a/src/util/CubeFunctions.ts
+++ b/src/util/CubeFunctions.ts
@@ -67,6 +67,9 @@ export async function initScryfall(): Promise<void> {
     });
     scryfall = data;
     scryfallReady.value = true;
+    // Signal to the next visit's HTML that cards are in IDB, so index.html can skip
+    // the <link rel="preload"> and avoid the "preloaded but not used" console warning.
+    try { localStorage.setItem('mtg-cube-stats:cards-cached', '1'); } catch { /* private mode / disabled */ }
     console.timeEnd('Loading Scryfall card data');
 }
 

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -1,10 +1,14 @@
 import { defineConfig } from "vite";
 import vue from '@vitejs/plugin-vue';
 
-// Emits `<link rel="preload">` for the Scryfall cards JSON so the browser starts
-// the ~10 MB (brotli) fetch during document parse rather than after the JS
-// graph resolves. Only runs on production builds; dev is skipped because the
-// hashed asset URL is unknown until bundling.
+// Emits an inline script that conditionally injects `<link rel="preload">` for
+// the Scryfall cards JSON so the browser starts the ~10 MB (brotli) fetch
+// during document parse rather than after the JS graph resolves. The preload
+// is skipped when a localStorage flag indicates the client already has the
+// cards in IndexedDB (return visitors); this avoids wasted bandwidth and the
+// "resource was preloaded but not used" console warning. Only runs on
+// production builds; dev is skipped because the hashed asset URL is unknown
+// until bundling.
 function cardsPreloadPlugin() {
     return {
         name: 'inject-cards-preload',
@@ -14,8 +18,9 @@ function cardsPreloadPlugin() {
                 a.type === 'asset' && a.name?.startsWith('cards-minimized') && a.fileName?.endsWith('.json'),
             );
             if (!cardsAsset) return html;
-            const tag = `    <link rel="preload" as="fetch" href="/${cardsAsset.fileName}" crossorigin>\n`;
-            return html.replace('</head>', `${tag}</head>`);
+            const href = `/${cardsAsset.fileName}`;
+            const script = `    <script>(function(){try{if(localStorage.getItem('mtg-cube-stats:cards-cached')==='1')return;}catch(e){}var l=document.createElement('link');l.rel='preload';l.as='fetch';l.crossOrigin='anonymous';l.href=${JSON.stringify(href)};document.head.appendChild(l);})();<\/script>\n`;
+            return html.replace('</head>', `${script}</head>`);
         },
     };
 }


### PR DESCRIPTION
## Problem

The unconditional `<link rel="preload" as="fetch">` for `cards-minimized.json` triggered a browser console warning:

> The resource https://cube.griselbrand.com/assets/cards-minimized-*.json was preloaded using link preload but not used within a few seconds from the window's load event.

**Root cause:** `loadJsonAsset`'s Tier 1 exact-URL IDB hit short-circuits before `fetch()` runs, so on return visits the preloaded ~10 MB response is downloaded but never consumed.

## Fix

Emit the preload from an inline script that checks a localStorage flag, and set the flag inside `initScryfall` after any successful load (Tier 1/2/3).

| Scenario | Preload emitted? | Result |
|---|---|---|
| First visit (no IDB, no flag) | Yes | Fetch consumes preload — fast cold load, no warning. |
| Return visit (IDB populated, flag set) | No | IDB serves instantly — no wasted bandwidth, no warning. |
| IDB cleared but flag persists | No | Falls back to lazy fetch. |
| localStorage blocked (private mode) | Yes | Same as before this change. |

The flag is self-healing: any user who has ever completed a cards load will suppress the preload on subsequent visits.