### PR TITLE
Eliminate tail hang when loading a collection

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -429,55 +429,79 @@ const checkResults = shallowRef<Map<string, Map<string, CheckResult>>>(new Map()
 // Cache keyed by `cubeId::conditionId::expression` to avoid redundant evaluation.
 const _checkResultsCache = new Map<string, CheckResult>();
 
+// Evaluate all active-collection checks for a single cube and populate
+// _checkResultsCache. Called during the streaming load so tail-time reactive
+// work becomes an all-cache-hit sweep. Safe to call more than once per cube.
+const primeChecksForCube = (cubeId: string, cube: Cube): void => {
+    const activeId = checksState.value.activeCollectionId;
+    if (!activeId) return;
+    const collection = checksState.value.collections.find(c => c.id === activeId);
+    if (!collection) return;
+    const ctx = { loadedCubes: loadedCubes.value };
+    for (const cond of collection.conditions) {
+        const parsed = parseCheckExpression(cond.expression);
+        if (!parsed.expression) continue;
+        const cacheKey = `${cubeId}::${cond.id}::${cond.expression}`;
+        if (_checkResultsCache.has(cacheKey)) continue;
+        bump(getActiveLoadProfile(), 'checksEvals');
+        _checkResultsCache.set(cacheKey, evaluateCheck(parsed.expression, cube.cards, ctx));
+    }
+};
+
 watchEffect(() => {
     bump(getActiveLoadProfile(), 'checksFires');
-    // Suspend during a preset load — otherwise this fires once per streamed cube
-    // and walks every already-loaded cube each time. One final recompute runs when
-    // loadingProgress.active flips false at the end of loadCollection.
+    // Suspend during a preset load — otherwise the effect fires per streamed
+    // cube (each processCube's microtask boundary flushes Vue's scheduler) and
+    // each fire reassigns checkResults, retriggering downstream table renders.
+    // Instead, primeChecksForCube warms _checkResultsCache per cube as it lands,
+    // so the single tail fire (unblocked by nextTick after active flips false)
+    // sees a fully warm cache and completes in microseconds.
     if (loadingProgress.active) return;
-    const results = new Map<string, Map<string, CheckResult>>();
-    const activeId = checksState.value.activeCollectionId;
-    if (!activeId) {
-        checkResults.value = results;
-        return;
-    }
-    const collection = checksState.value.collections.find(c => c.id === activeId);
-    if (!collection) {
-        checkResults.value = results;
-        return;
-    }
-
-    const parsedConditions = collection.conditions
-        .map(cond => ({ id: cond.id, expression: cond.expression, parsed: parseCheckExpression(cond.expression) }))
-        .filter(c => c.parsed.expression !== null);
-
-    const usedKeys = new Set<string>();
-
-    for (const [cubeId, cube] of Object.entries(visibleLoadedCubes.value)) {
-        const cubeResults = new Map<string, CheckResult>();
-        const ctx = { loadedCubes: loadedCubes.value };
-        for (const { id, expression, parsed } of parsedConditions) {
-            if (parsed.expression) {
-                const cacheKey = `${cubeId}::${id}::${expression}`;
-                usedKeys.add(cacheKey);
-                let result = _checkResultsCache.get(cacheKey);
-                if (!result) {
-                    bump(getActiveLoadProfile(), 'checksEvals');
-                    result = evaluateCheck(parsed.expression, cube.cards, ctx);
-                    _checkResultsCache.set(cacheKey, result);
-                }
-                cubeResults.set(id, result);
-            }
+    timed(getActiveLoadProfile(), 'checks', () => {
+        const results = new Map<string, Map<string, CheckResult>>();
+        const activeId = checksState.value.activeCollectionId;
+        if (!activeId) {
+            checkResults.value = results;
+            return;
         }
-        results.set(cubeId, cubeResults);
-    }
+        const collection = checksState.value.collections.find(c => c.id === activeId);
+        if (!collection) {
+            checkResults.value = results;
+            return;
+        }
 
-    // Prune stale cache entries
-    for (const key of _checkResultsCache.keys()) {
-        if (!usedKeys.has(key)) _checkResultsCache.delete(key);
-    }
+        const parsedConditions = collection.conditions
+            .map(cond => ({ id: cond.id, expression: cond.expression, parsed: parseCheckExpression(cond.expression) }))
+            .filter(c => c.parsed.expression !== null);
 
-    checkResults.value = results;
+        const usedKeys = new Set<string>();
+
+        for (const [cubeId, cube] of Object.entries(visibleLoadedCubes.value)) {
+            const cubeResults = new Map<string, CheckResult>();
+            const ctx = { loadedCubes: loadedCubes.value };
+            for (const { id, expression, parsed } of parsedConditions) {
+                if (parsed.expression) {
+                    const cacheKey = `${cubeId}::${id}::${expression}`;
+                    usedKeys.add(cacheKey);
+                    let result = _checkResultsCache.get(cacheKey);
+                    if (!result) {
+                        bump(getActiveLoadProfile(), 'checksEvals');
+                        result = evaluateCheck(parsed.expression, cube.cards, ctx);
+                        _checkResultsCache.set(cacheKey, result);
+                    }
+                    cubeResults.set(id, result);
+                }
+            }
+            results.set(cubeId, cubeResults);
+        }
+
+        // Prune stale cache entries
+        for (const key of _checkResultsCache.keys()) {
+            if (!usedKeys.has(key)) _checkResultsCache.delete(key);
+        }
+
+        checkResults.value = results;
+    });
 });
 
 const peerStats = computed(() => {
@@ -836,6 +860,7 @@ const loadCollection = async (presetName: string) => {
                     case 'cache': {
                         loadedCubes.value[id] = timed(profile, 'enrichCube', () => { bump(profile, 'enrichCount'); return enrichCube(cached!.data); });
                         timed(profile, 'warmSim', () => { bump(profile, 'warmSimCount'); warmSimilarityCacheForCube(id, loadedCubes.value, similarityMatrix.value); });
+                        timed(profile, 'checks', () => primeChecksForCube(id, loadedCubes.value[id]));
                         if (source.refresh === 'preload') void backgroundRefreshFromPreload(id, meta);
                         else if (source.refresh === 'live') void backgroundRefreshCube(cached!.id);
                         return;
@@ -846,6 +871,7 @@ const loadCollection = async (presetName: string) => {
                         void setCachedCubeIfNewer(id, cube, cube.fetchedAt ?? meta.fetchedAt);
                         loadedCubes.value[id] = timed(profile, 'enrichCube', () => { bump(profile, 'enrichCount'); return enrichCube(cube); });
                         timed(profile, 'warmSim', () => { bump(profile, 'warmSimCount'); warmSimilarityCacheForCube(id, loadedCubes.value, similarityMatrix.value); });
+                        timed(profile, 'checks', () => primeChecksForCube(id, loadedCubes.value[id]));
                         return;
                     }
                     case 'live': {
@@ -855,6 +881,7 @@ const loadCollection = async (presetName: string) => {
                         await setCachedCube(id, cube, fetchedAt);
                         loadedCubes.value[id] = timed(profile, 'enrichCube', () => { bump(profile, 'enrichCount'); return enrichCube(cube); });
                         timed(profile, 'warmSim', () => { bump(profile, 'warmSimCount'); warmSimilarityCacheForCube(id, loadedCubes.value, similarityMatrix.value); });
+                        timed(profile, 'checks', () => primeChecksForCube(id, loadedCubes.value[id]));
                         return;
                     }
                 }
@@ -904,6 +931,10 @@ const loadCollection = async (presetName: string) => {
         bump(profile, 'cubePromisesTotal', performance.now() - profileStart);
     } finally {
         loadingProgress.active = false;
+        // Wait for the reactive flush so the end-of-load checkResults watchEffect
+        // (gated on loadingProgress.active) can attribute its cost to this profile
+        // before we clear the active profile.
+        await nextTick();
         console.timeEnd(`Load Collection: ${presetName}`);
         reportLoadProfile(presetName, profile);
         setActiveLoadProfile(null);

--- a/src/util/CardFilterParser.ts
+++ b/src/util/CardFilterParser.ts
@@ -191,28 +191,50 @@ function normalizeNode(node: QueryNode): QueryNode {
     return node;
 }
 
+// Memoize by trimmed input. parseQuery is called per-card in filter hot paths and
+// per-cube in the checks recompute; instantiating a nearley Parser + walking the
+// grammar dominated `evaluateCheck` cost before this cache landed.
+const PARSE_CACHE_LIMIT = 500;
+const parseCache = new Map<string, ParseResult>();
+
 export function parseQuery(input: string): ParseResult {
     const trimmed = input.trim();
     if (!trimmed) {
         return { ast: null, error: null };
     }
 
+    const cached = parseCache.get(trimmed);
+    if (cached) return cached;
+
+    let result: ParseResult;
     try {
         const parser = new nearley.Parser(nearley.Grammar.fromCompiled(grammar));
         parser.feed(trimmed);
         const results = parser.results;
 
         if (!results || results.length === 0) {
-            return { ast: null, error: 'Incomplete query — check for missing values after operators.' };
+            result = { ast: null, error: 'Incomplete query — check for missing values after operators.' };
+        } else {
+            // Nearley can return multiple parse trees for ambiguous grammars; take the first.
+            const ast = normalizeNode(results[0] as QueryNode);
+            result = { ast, error: null };
         }
-
-        // Nearley can return multiple parse trees for ambiguous grammars; take the first.
-        const ast = normalizeNode(results[0] as QueryNode);
-        return { ast, error: null };
     } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : String(e);
         // Trim nearley's verbose token dumps to a short user-facing message
         const shortMsg = msg.split('\n')[0].replace(/^Error: /, '');
-        return { ast: null, error: `Parse error: ${shortMsg}` };
+        result = { ast: null, error: `Parse error: ${shortMsg}` };
     }
+
+    if (parseCache.size >= PARSE_CACHE_LIMIT) {
+        // Evict oldest quarter to keep the cache bounded under adversarial input.
+        const evict = Math.floor(PARSE_CACHE_LIMIT / 4);
+        let i = 0;
+        for (const k of parseCache.keys()) {
+            if (i++ >= evict) break;
+            parseCache.delete(k);
+        }
+    }
+    parseCache.set(trimmed, result);
+    return result;
 }

--- a/src/util/CheckEvaluator.ts
+++ b/src/util/CheckEvaluator.ts
@@ -16,8 +16,16 @@ function compare(lhs: number, op: string, rhs: number): boolean {
   }
 }
 
+// Cache the evaluator-shaped shadow object per card. Enriched cards are stable
+// after enrichCube; a single (~500 cards × cubes) allocation batch replaces
+// (cards × conditions × cubes) allocations at check-eval time.
+const evalRowCache = new WeakMap<object, any>();
 function toEvaluatorRow(card: CubeCard): any {
-  return { ...card, effectiveColors: card.colors, effectiveColorIdentity: card.colorIdentity };
+  const cached = evalRowCache.get(card as unknown as object);
+  if (cached) return cached;
+  const row = { ...card, effectiveColors: card.colors, effectiveColorIdentity: card.colorIdentity };
+  evalRowCache.set(card as unknown as object, row);
+  return row;
 }
 
 function countMatching(cardFilter: string, cards: CubeCard[], ctx: FilterContext): number {

--- a/src/util/LoadProfile.ts
+++ b/src/util/LoadProfile.ts
@@ -36,6 +36,7 @@ export interface LoadProfile {
     similarityLoad: number;
     checksFires: number;
     checksEvals: number;
+    checks: number;
     cubePromisesTotal: number;
 }
 
@@ -52,6 +53,7 @@ export function makeLoadProfile(): LoadProfile {
         similarityLoad: 0,
         checksFires: 0,
         checksEvals: 0,
+        checks: 0,
         cubePromisesTotal: 0,
     };
 }


### PR DESCRIPTION
Before: overlay hung ~1.5s after the progress bar hit N/N while the gated
checkResults watchEffect walked every loaded cube × condition in one blocking
sweep. Profiling attributed ~1475ms of a 2853ms preset load to that single tail
fire.

- CardFilterParser.parseQuery: memoize by trimmed input (bounded at 500 entries).
  Was instantiating a fresh nearley Parser and re-parsing the grammar per call;
  the checks recompute called it once per cube per condition.
- CheckEvaluator.toEvaluatorRow: WeakMap-cache the evaluator-shaped shadow
  object per card. Cuts ~142k spread allocations per preset load to one alloc
  per card, reused across every condition on that cube.
- App.vue: add primeChecksForCube() and invoke it inside processCube for each
  tier so check evaluations happen as cubes stream in, populating
  _checkResultsCache. The gated watchEffect still fires once at the tail (now
  behind nextTick so its cost attributes to the active load profile), but sees
  an all-cache-hit sweep and completes in microseconds. Downstream re-renders
  stay at one instead of the 72 an ungated effect produced.
- LoadProfile: add a 'checks' wall-time bucket so future regressions in this
  path are visible in the LOAD PROFILE console line.

Result (CubeCon 2026, 71 cubes, warm IDB, 3-run avg):
  Total load:  2853ms -> ~1835ms  (-36%)
  Tail hang:   ~1475ms -> ~0ms   (overlay dismisses on same frame as active=false)
  checks:      1475ms -> ~508ms  (now distributed across streaming, not tail)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>