### PR TITLE
fix: clear preset info when loading another collection (fixes #566)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -626,7 +626,12 @@ const saveCollection = (name: string) => {
 const loadUserCollection = async (name: string) => {
     const collection = userCollections.value.find(c => c.name === name);
     if (!collection) return;
+    // Clear preset state before addCubes runs — its own guard skips this reset
+    // when presetBaseIds is non-empty, leaving stale PresetHeader details visible.
+    activePresetName.value = null;
+    presetBaseIds.value = new Set();
     loadedCubes.value = {};
+    similarityMatrix.value = {};
     await addCubes(collection.cubeIds);
 };
 


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>